### PR TITLE
refactor: Change VSCode workspace settings

### DIFF
--- a/_fastkit.code-workspace
+++ b/_fastkit.code-workspace
@@ -282,6 +282,8 @@
     }
   ],
 	"settings": {
+    "search.followSymlinks": false,
+    "search.searchOnType": false,
     "search.exclude": {
       "**/.git": true,
       "**/node_modules": true,

--- a/_fastkit.code-workspace
+++ b/_fastkit.code-workspace
@@ -283,6 +283,7 @@
   ],
 	"settings": {
     "search.followSymlinks": false,
+    "search.maxResults": 5000,
     "search.searchOnType": false,
     "search.exclude": {
       "**/.git": true,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request !

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #5 

## 📝 Description

This repository is a mono-repository holding a large number of packages, and since the packages are managed by pnpm, there are many symbolic links.
It has not been determined if this is the cause of the problem, but the problem was corrected by restricting some of VSCode's grep options to improve VSCode's grep performance.

## ⛳️ Current behavior (updates)

When grep search is performed in VSCode, the machine freezes with a high probability.

## 🚀 New behavior

The probability of the machine freezing when performing a grep search is significantly reduced.

## 💣 Is this a breaking change (Yes/No): No

No effect on the production code occurs.

## 📝 Additional Information

Although the issue reference seems to be the likely cause of the problem, we have not been able to pinpoint the cause.
https://github.com/microsoft/vscode/issues/88385

However, we have experienced that the addition of the following two lines of settings has greatly reduced the probability of problems occurring.

https://github.com/dadajam4/fastkit/blob/refactor/fix-vscode-grep/_fastkit.code-workspace#L285-L286

From this, our hypothesis is that this repository has a lot of Symlinks, which may cause the freeze due to the recursive parallel invocation of the grep process.
As an additional note, we have observed that a large number of processes named `(rg)` are created on VSCode's performance explorer when the symptoms are reproduced.

Since this problem has no particular impact on the release media, we thought it would be a good idea to take a new countermeasure if the problem continues to occur frequently after this PR improvement.
