### PR TITLE
Fix/stylelint config deprecation warn

### DIFF
--- a/.changeset/itchy-tomatoes-hide.md
+++ b/.changeset/itchy-tomatoes-hide.md
@@ -1,0 +1,7 @@
+---
+'@fastkit/stylelint-config': patch
+---
+
+Removed deprecated formatter-related rules in Stylelint and fixed warnings.
+
+[Stylelint v15 migration guide](https://stylelint.io/migration-guide/to-15/#deprecated-stylistic-rules)

--- a/packages/stylelint-config/index.cjs
+++ b/packages/stylelint-config/index.cjs
@@ -4,15 +4,12 @@ module.exports = {
   extends: [
     'stylelint-config-standard',
     'stylelint-prettier/recommended',
-    'stylelint-config-prettier',
     'stylelint-config-recess-order',
   ],
   rules: {
     'at-rule-no-unknown': null,
     'scss/at-rule-no-unknown': true,
     'prettier/prettier': true,
-    indentation: 2,
-    'string-quotes': 'single',
     'length-zero-no-unit': null,
     'value-keyword-case': null,
     'no-descending-specificity': null,

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -43,7 +43,6 @@
     "postcss-html": "^1.5.0",
     "postcss-scss": "^4.0.6",
     "stylelint-config-css-modules": "^4.2.0",
-    "stylelint-config-prettier": "^9.0.5",
     "stylelint-config-recess-order": "^4.0.0",
     "stylelint-config-standard": "^31.0.0",
     "stylelint-prettier": "^3.0.0",

--- a/packages/vui/src/styles/elevation.scss
+++ b/packages/vui/src/styles/elevation.scss
@@ -1,6 +1,7 @@
 @use './core.scss';
 
 $z: 24;
+
 @while $z >= 0 {
   .elevation-#{$z} {
     @include core.elevation($z, true);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -542,7 +542,6 @@ importers:
       postcss-html: ^1.5.0
       postcss-scss: ^4.0.6
       stylelint-config-css-modules: ^4.2.0
-      stylelint-config-prettier: ^9.0.5
       stylelint-config-recess-order: ^4.0.0
       stylelint-config-standard: ^31.0.0
       stylelint-prettier: ^3.0.0
@@ -551,7 +550,6 @@ importers:
       postcss-html: 1.5.0
       postcss-scss: 4.0.6
       stylelint-config-css-modules: 4.2.0
-      stylelint-config-prettier: 9.0.5
       stylelint-config-recess-order: 4.0.0
       stylelint-config-standard: 31.0.0
       stylelint-prettier: 3.0.0
@@ -8939,17 +8937,6 @@ packages:
         optional: true
     optionalDependencies:
       stylelint-scss: 4.6.0
-    dev: false
-
-  /stylelint-config-prettier/9.0.5:
-    resolution: {integrity: sha512-U44lELgLZhbAD/xy/vncZ2Pq8sh2TnpiPvo38Ifg9+zeioR+LAkHu0i6YORIOxFafZoVg0xqQwex6e6F25S5XA==}
-    engines: {node: '>= 12'}
-    hasBin: true
-    peerDependencies:
-      stylelint: '>= 11.x < 15'
-    peerDependenciesMeta:
-      stylelint:
-        optional: true
     dev: false
 
   /stylelint-config-recess-order/4.0.0:


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request !

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #8 

## 📝 Description

Modify stylelint-config so that deprecation warnings are not displayed.

## ⛳️ Current behavior (updates)

When I run stylelint, I get a deprecation warning.

## 🚀 New behavior

stylelint completes execution without warning.

## 💣 Is this a breaking change (Yes/No): No
