### PR TITLE
feat(vui-wysiwyg): Added tools for custom tags

### DIFF
--- a/.changeset/thick-poets-hope.md
+++ b/.changeset/thick-poets-hope.md
@@ -1,0 +1,5 @@
+---
+'@fastkit/vui-wysiwyg': minor
+---
+
+Added tools for custom tags

--- a/apps/docs/src/pages/vui/index/components/wysiwygs.scss
+++ b/apps/docs/src/pages/vui/index/components/wysiwygs.scss
@@ -1,3 +1,11 @@
 .pg-docs-components-wysiwygs {
   display: block;
+
+  pg-custom-tag {
+    background: cyan;
+  }
+
+  .pg-custom-tag-class {
+    background: cyan;
+  }
 }

--- a/apps/docs/src/pages/vui/index/components/wysiwygs.tsx
+++ b/apps/docs/src/pages/vui/index/components/wysiwygs.tsx
@@ -22,6 +22,7 @@ import {
   WysiwygLinter,
   WysiwygLinterBadWords,
   WysiwygTextAlignTool,
+  createWysiwygCustomTagTool,
 } from '@fastkit/vui-wysiwyg';
 import { DocsSection } from '../../../-components';
 
@@ -53,6 +54,13 @@ const tools = [
   WysiwygOrderedListTool,
   WysiwygLinkTool,
   WysiwygHistoryTool,
+  createWysiwygCustomTagTool('custom-tag', {
+    // tag: 'pg-custom-tag',
+    icon: 'mdi-asterisk',
+    attrs: {
+      class: 'pg-custom-tag-class',
+    },
+  }),
 ];
 export default defineComponent({
   setup() {

--- a/packages/vui-wysiwyg/src/extensions/custom-tag.ts
+++ b/packages/vui-wysiwyg/src/extensions/custom-tag.ts
@@ -1,0 +1,126 @@
+import { Extension, mergeAttributes, Mark } from '@tiptap/vue-3';
+import '@tiptap/extension-text-style';
+// import '@tiptap/vue-3';
+
+export type WysiwygCustomTagSettings = {
+  /**
+   * tag name
+   *
+   * Either the html default tag name or a custom tag name is acceptable
+   *
+   * @default "span"
+   */
+  tag: string;
+
+  /**
+   * HTML Attributes
+   *
+   * Attributes to be assigned to tags such as `class`, `data-xxx`, etc.
+   */
+  attrs?: Record<any, string>;
+};
+
+declare module '@tiptap/vue-3' {
+  interface Commands<ReturnType> {
+    customTag: {
+      /**
+       * Set the custom tag
+       */
+      setCustomTag: (markName: string) => ReturnType;
+      /**
+       * Toggle the custom tag
+       */
+      toggleCustomTag: (markName: string) => ReturnType;
+      /**
+       * Unset the custom tag
+       */
+      unsetCustomTag: (markName: string) => ReturnType;
+    };
+  }
+}
+
+// export type WysiwygCustomTagSettings = WysiwygCustomTagOptions & {
+//   /**
+//    * extension name
+//    */
+//   name: string;
+// };
+
+export function createWysiwygCustomTagMark(
+  name: string,
+  settings: Partial<WysiwygCustomTagSettings>,
+) {
+  const { tag = 'span', attrs } = settings;
+  const attrEntries = attrs && Object.entries(attrs);
+  const attrNames = attrEntries && attrEntries.map(([name]) => name);
+
+  const getElementAttrs = (
+    el: HTMLElement,
+  ): Record<any, string> | undefined => {
+    if (!attrNames) return;
+
+    return el.getAttributeNames().reduce((acc, name) => {
+      return { ...acc, [name]: el.getAttribute(name) };
+    }, {});
+  };
+
+  const isMatchedElementAttrs = (elAttrs: Record<any, string>): boolean => {
+    if (!attrEntries) return true;
+    return attrEntries.every(([name, value]) => elAttrs[name] === value);
+  };
+
+  return Mark.create<WysiwygCustomTagSettings>({
+    name,
+
+    addOptions() {
+      return {
+        tag,
+        attrs: attrs && { ...attrs },
+      };
+    },
+    parseHTML() {
+      return [
+        {
+          tag,
+          getAttrs: (el: any) => {
+            if (!attrs) return null;
+            const elAttrs = getElementAttrs(el);
+            if (!elAttrs) return false;
+            return isMatchedElementAttrs(el) && null;
+          },
+        },
+      ];
+    },
+    renderHTML({ HTMLAttributes }) {
+      return [
+        tag,
+        attrs ? mergeAttributes(attrs, HTMLAttributes) : HTMLAttributes,
+        0,
+      ];
+    },
+  });
+}
+
+export const WysiwygCustomTagExtenstion =
+  Extension.create<WysiwygCustomTagSettings>({
+    name: 'custom-tag',
+    addCommands() {
+      return {
+        setCustomTag:
+          (markName) =>
+          ({ chain }) => {
+            return chain().setMark(markName).run();
+          },
+        unsetCustomTag:
+          (markName) =>
+          ({ chain }) => {
+            return chain().unsetMark(markName).run();
+          },
+        toggleCustomTag:
+          (markName) =>
+          ({ chain }) => {
+            return chain().toggleMark(markName).run();
+          },
+      };
+    },
+  });

--- a/packages/vui-wysiwyg/src/extensions/index.ts
+++ b/packages/vui-wysiwyg/src/extensions/index.ts
@@ -1,2 +1,3 @@
 export * from './linter';
 export * from './color';
+export * from './custom-tag';

--- a/packages/vui-wysiwyg/src/schemes.ts
+++ b/packages/vui-wysiwyg/src/schemes.ts
@@ -190,17 +190,31 @@ export function resolveRawWysiwygExtensions(
   return raws.map((raw) => resolveRawWysiwygExtension(raw, ctx));
 }
 
+export type WysiwygEditorToolIcon =
+  | IconName
+  | ((ctx: WysiwygEditorContext) => IconName | (() => VNodeChild) | undefined);
+
+/**
+ * Tool Configuration
+ */
 export interface WysiwygEditorTool {
+  /**
+   * Tool Key
+   *
+   * Must be unique to identify the tool
+   */
   key: string;
-  icon:
-    | IconName
-    | ((
-        ctx: WysiwygEditorContext,
-      ) => IconName | (() => VNodeChild) | undefined);
+  /** Icons to be displayed on the toolbar */
+  icon: WysiwygEditorToolIcon;
+  /** Conditions for displaying the icon as active */
   active?: boolean | ((ctx: WysiwygEditorContext) => boolean);
+  /** Conditions for deactivating the icon */
   disabled?: boolean | ((ctx: WysiwygEditorContext) => boolean);
+  /** Handler when mark text is clicked */
   onClick: (ctx: WysiwygEditorContext, ev: MouseEvent) => any;
+  /** Whether to display tools in floating menu or not */
   floating?: boolean;
+  /** Extensions that the tool depends on */
   extensions?: Extensions;
 }
 

--- a/packages/vui-wysiwyg/src/tools/custom-tag.ts
+++ b/packages/vui-wysiwyg/src/tools/custom-tag.ts
@@ -1,0 +1,39 @@
+import { WysiwygEditorToolFactory, WysiwygEditorTool } from '../schemes';
+import {
+  createWysiwygCustomTagMark,
+  WysiwygCustomTagSettings,
+  WysiwygCustomTagExtenstion,
+} from '../extensions/custom-tag';
+
+export interface WysiwygCustomTagToolSettings
+  extends Pick<WysiwygEditorTool, 'icon' | 'floating'>,
+    Partial<WysiwygCustomTagSettings> {}
+
+/**
+ * Generate Custom Tag Tool
+ *
+ * @param markName - Mark name
+ * @param settings - Tool Configuration
+ * @returns Generated Tool
+ */
+export function createWysiwygCustomTagTool(
+  markName: string,
+  settings: WysiwygCustomTagToolSettings,
+): WysiwygEditorToolFactory {
+  const Mark = createWysiwygCustomTagMark(markName, settings);
+  const { icon, floating = true } = settings;
+
+  return (vui) => {
+    const tool: WysiwygEditorTool = {
+      key: `customTag:${markName}`,
+      icon,
+      floating,
+      active: ({ editor }) => editor.isActive(markName),
+      onClick: ({ editor }) => {
+        editor.chain().focus().toggleCustomTag(markName).run();
+      },
+      extensions: [WysiwygCustomTagExtenstion, Mark.configure(settings)],
+    };
+    return tool;
+  };
+}

--- a/packages/vui-wysiwyg/src/tools/index.ts
+++ b/packages/vui-wysiwyg/src/tools/index.ts
@@ -7,3 +7,4 @@ export * from './link';
 export * from './ordered-list';
 export * from './color';
 export * from './text-align';
+export * from './custom-tag';


### PR DESCRIPTION

Closes #19 

## 📝 Description

Added a tool to vui-wysiwyg to generate custom tags.

## 💣 Is this a breaking change (Yes/No): No
