### PR TITLE
fix: hoist pettern

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-shamefully-hoist: true
+shamefully-hoist=true


### PR DESCRIPTION
## 📝 Description

An error in the `.npmrc` `shamefully-hoist` setting has been corrected.