### PR TITLE
Fix/dialog default backdrop

### DIFF
--- a/.changeset/hungry-pigs-nail.md
+++ b/.changeset/hungry-pigs-nail.md
@@ -1,0 +1,7 @@
+---
+'@fastkit/vui': patch
+---
+
+The alert and confirm dialogs were designed to display backdrops by default, but this was no longer being done due to the vue-stack migration.
+This behavior has been fixed and backdrops are now displayed as before.
+Backdrops can still be optionally disabled.

--- a/packages/vui/src/service.tsx
+++ b/packages/vui/src/service.tsx
@@ -260,8 +260,10 @@ export class VuiService {
       if (!actions.length) {
         actions.push(this.stackAction('ok'));
       }
+      const backdrop = props?.backdrop == null ? true : props?.backdrop;
       return {
         ...props,
+        backdrop,
         actions,
       };
     });
@@ -271,8 +273,10 @@ export class VuiService {
       if (!actions.length) {
         actions.push(this.stackAction('cancel'), this.stackAction('ok'));
       }
+      const backdrop = props?.backdrop == null ? true : props?.backdrop;
       return {
         ...props,
+        backdrop,
         actions,
       };
     });


### PR DESCRIPTION
## 📝 Description

The alert and confirm dialogs were designed to display backdrops by default, but this was no longer being done due to the vue-stack migration.
This behavior has been fixed and backdrops are now displayed as before.
Backdrops can still be optionally disabled.
