### PR TITLE
Fix/plugboy polyrepo

### DIFF
--- a/.changeset/unlucky-ducks-attend.md
+++ b/.changeset/unlucky-ducks-attend.md
@@ -1,0 +1,7 @@
+---
+'@fastkit/plugboy': patch
+---
+
+Fixed failure to retrieve configuration files in projects configured with polyrepo.
+
+This was due to the `allowMissing` option of the `findConfig` method sometimes not working properly.

--- a/packages/plugboy/src/utils/file.ts
+++ b/packages/plugboy/src/utils/file.ts
@@ -155,7 +155,7 @@ export async function findConfig<
   const next = (err?: unknown) => {
     const nextDir = path.dirname(dir);
     if (nextDir !== dir) {
-      return findConfig(fileName, nextDir, currentDepth + 1);
+      return findConfig(settings, nextDir, currentDepth + 1);
     }
     if (allowMissing) return null as any;
     throw err || new Error(`missing config "${fileName}"`);


### PR DESCRIPTION
## 📝 Description

Fixed failure to retrieve configuration files in projects configured with polyrepo.

This was due to the `allowMissing` option of the `findConfig` method sometimes not working properly.
