### PR TITLE
Fix/validate timing change

### DIFF
--- a/.changeset/custom-changelog-config.ts
+++ b/.changeset/custom-changelog-config.ts
@@ -1,0 +1,20 @@
+import { ChangelogFunctions } from "@changesets/types";
+import changelogGithub from '@changesets/changelog-github';
+
+function escapeAtMark(str: string) {
+  return str.replace(/([a-z])@/ig, '$1 v');
+}
+
+const functions: ChangelogFunctions = {
+  async getDependencyReleaseLine(changesets, dependenciesUpdated, options) {
+    const processed = await changelogGithub.getDependencyReleaseLine(changesets, dependenciesUpdated, options);
+    return escapeAtMark(processed);
+  },
+  async getReleaseLine(changeset, type, changelogOpts) {
+    const processed = await changelogGithub.getReleaseLine(changeset, type, changelogOpts);
+    return escapeAtMark(processed);
+  },
+};
+
+
+export default functions;

--- a/.changeset/silent-mails-lay.md
+++ b/.changeset/silent-mails-lay.md
@@ -1,0 +1,5 @@
+---
+'@fastkit/vue-form-control': patch
+---
+
+Fixed a problem where validation would work when `change` was specified for Validate timing, even though the value had not been changed.

--- a/packages/vue-form-control/src/composables/node.tsx
+++ b/packages/vue-form-control/src/composables/node.tsx
@@ -526,7 +526,10 @@ export class FormNodeControl<T = any, D = T> {
     this._parentNode = parentNode;
     this._parentForm = parentForm;
 
+    let isMounted = false;
+
     onMounted(() => {
+      isMounted = true;
       this._cii = getCurrentInstance();
     });
 
@@ -675,7 +678,7 @@ export class FormNodeControl<T = any, D = T> {
 
       if (
         this.shouldValidate ||
-        this.validateTimingIsChange ||
+        (isMounted && this.validateTimingIsChange) ||
         this.validateTimingIsAlways
       ) {
         this.validateSelf();

--- a/packages/vue-form-control/src/composables/selector-item.tsx
+++ b/packages/vue-form-control/src/composables/selector-item.tsx
@@ -25,7 +25,10 @@ import {
 
 export function createFormSelectorItemProps() {
   return {
-    ...createFormNodeProps({ modelValue: Boolean }),
+    ...createFormNodeProps({
+      modelValue: Boolean,
+      defaultValidateTiming: 'change',
+    }),
     ...createPropsOptions({
       /** selection value */
       value: {


### PR DESCRIPTION
## 📝 Description

Fixed a problem where validation would work when `change` was specified for Validate timing, even though the value had not been changed.