### PR TITLE
Feat/add rule error constraints

### DIFF
--- a/.changeset/curvy-rivers-taste.md
+++ b/.changeset/curvy-rivers-taste.md
@@ -1,0 +1,6 @@
+---
+'@fastkit/rules': patch
+---
+
+Validation error objects are now accompanied by an expected value object.
+This allows for custom error messages to use the expected value used when validating the value.

--- a/packages/rules/src/factories/__tests__/each.spec.ts
+++ b/packages/rules/src/factories/__tests__/each.spec.ts
@@ -35,6 +35,7 @@ describe('factories/each', () => {
       const result = await rule.validate(list);
       const expectedValue = {
         $$symbol: 'ValidationError',
+        constraints: rule.constraints,
         name: 'each',
         eachPrefix: undefined,
         path: undefined,
@@ -44,6 +45,7 @@ describe('factories/each', () => {
         children: [
           {
             $$symbol: 'ValidationError',
+            constraints: undefined,
             name: 'required',
             eachPrefix: undefined,
             path: 0,
@@ -54,6 +56,7 @@ describe('factories/each', () => {
           },
           {
             $$symbol: 'ValidationError',
+            constraints: undefined,
             name: 'required',
             eachPrefix: undefined,
             path: 1,
@@ -64,6 +67,7 @@ describe('factories/each', () => {
           },
           {
             $$symbol: 'ValidationError',
+            constraints: undefined,
             name: 'required',
             eachPrefix: undefined,
             path: 2,
@@ -74,6 +78,7 @@ describe('factories/each', () => {
           },
           {
             $$symbol: 'ValidationError',
+            constraints: 5,
             name: 'maxLength',
             eachPrefix: undefined,
             path: 4,
@@ -107,6 +112,7 @@ describe('factories/each', () => {
       ];
       const expectedValue = {
         $$symbol: 'ValidationError',
+        constraints: myRule.constraints,
         name: 'each',
         eachPrefix: undefined,
         path: undefined,
@@ -116,6 +122,7 @@ describe('factories/each', () => {
         children: [
           {
             $$symbol: 'ValidationError',
+            constraints: undefined,
             name: 'required',
             eachPrefix: undefined,
             path: 0,
@@ -126,6 +133,7 @@ describe('factories/each', () => {
           },
           {
             $$symbol: 'ValidationError',
+            constraints: undefined,
             name: 'required',
             eachPrefix: undefined,
             path: 1,
@@ -136,6 +144,7 @@ describe('factories/each', () => {
           },
           {
             $$symbol: 'ValidationError',
+            constraints: undefined,
             name: 'required',
             eachPrefix: undefined,
             path: 2,
@@ -146,6 +155,7 @@ describe('factories/each', () => {
           },
           {
             $$symbol: 'ValidationError',
+            constraints: undefined,
             name: 'required',
             eachPrefix: undefined,
             path: 4,
@@ -156,6 +166,7 @@ describe('factories/each', () => {
           },
           {
             $$symbol: 'ValidationError',
+            constraints: 5,
             name: 'maxLength',
             eachPrefix: undefined,
             path: 5,
@@ -166,6 +177,7 @@ describe('factories/each', () => {
           },
           {
             $$symbol: 'ValidationError',
+            constraints: 5,
             name: 'maxLength',
             eachPrefix: undefined,
             path: 8,
@@ -194,6 +206,7 @@ describe('factories/each', () => {
       });
       const expectedValue = {
         $$symbol: 'ValidationError',
+        constraints: myRule.constraints,
         name: 'each',
         eachPrefix: undefined,
         path: undefined,

--- a/packages/rules/src/factories/__tests__/fields.spec.ts
+++ b/packages/rules/src/factories/__tests__/fields.spec.ts
@@ -129,6 +129,7 @@ describe('factories/fields', () => {
 
       const expectValueSnapShot = {
         $$symbol: 'ValidationError',
+        constraints: undefined,
         name: 'user',
         eachPrefix: undefined,
         path: 'user',
@@ -138,33 +139,36 @@ describe('factories/fields', () => {
         children: [
           {
             $$symbol: 'ValidationError',
+            children: undefined,
+            constraints: undefined,
             name: 'required',
             eachPrefix: '["user"]',
             path: 'name',
             fullPath: '["user"]["name"]',
             value: undefined,
             message: 'This item is required.',
-            children: undefined,
           },
           {
             $$symbol: 'ValidationError',
+            children: undefined,
+            constraints: undefined,
             name: 'required',
             eachPrefix: '["user"]',
             path: 'email',
             fullPath: '["user"]["email"]',
             value: undefined,
             message: 'This item is required.',
-            children: undefined,
           },
           {
             $$symbol: 'ValidationError',
+            children: undefined,
+            constraints: undefined,
             name: 'fields',
             eachPrefix: '["user"]',
             path: 'type',
             fullPath: '["user"]["type"]',
             value: undefined,
             message: 'The object does not meet the constraints.',
-            children: undefined,
           },
         ],
       };
@@ -175,8 +179,16 @@ describe('factories/fields', () => {
           const result = (await userRule.validate(value, {
             path: 'user',
           })) as ValidationError;
+          const cloned = JSON.parse(JSON.stringify(expectValueSnapShot));
+          cloned.children.forEach((row: any, i: number) => {
+            const same = (result as any).children[i];
+            row.children = expectValueSnapShot.children[i].children;
+            row.constraints = same.constraints;
+            row.value = expectValueSnapShot.children[i].value;
+          });
           expect(result).toEqual({
-            ...JSON.parse(JSON.stringify(expectValueSnapShot)),
+            ...cloned,
+            constraints: userRule.constraints,
             message: createMessage(value),
             value,
           });
@@ -199,6 +211,7 @@ describe('factories/fields', () => {
         });
         const expectValueSnapShot = {
           $$symbol: 'ValidationError',
+          constraints: undefined,
           name: 'user',
           path: 2,
           fullPath: '[2]',
@@ -214,6 +227,8 @@ describe('factories/fields', () => {
           children: [
             {
               $$symbol: 'ValidationError',
+              children: undefined,
+              constraints: undefined,
               name: 'required',
               eachPrefix: '[2]',
               path: 'name',
@@ -223,6 +238,8 @@ describe('factories/fields', () => {
             },
             {
               $$symbol: 'ValidationError',
+              children: undefined,
+              constraints: 10,
               name: 'maxLength',
               eachPrefix: '[2]',
               path: 'email',
@@ -232,6 +249,7 @@ describe('factories/fields', () => {
             },
             {
               $$symbol: 'ValidationError',
+              constraints: undefined,
               name: 'fields',
               eachPrefix: '[2]',
               path: 'type',
@@ -244,6 +262,8 @@ describe('factories/fields', () => {
               children: [
                 {
                   $$symbol: 'ValidationError',
+                  children: undefined,
+                  constraints: undefined,
                   name: 'required',
                   eachPrefix: '[2]["type"]',
                   path: 'type',
@@ -253,6 +273,8 @@ describe('factories/fields', () => {
                 },
                 {
                   $$symbol: 'ValidationError',
+                  children: undefined,
+                  constraints: 10,
                   name: 'maxLength',
                   eachPrefix: '[2]["type"]',
                   path: 'desc',
@@ -264,8 +286,16 @@ describe('factories/fields', () => {
             },
           ],
         };
+        const cloned = JSON.parse(JSON.stringify(expectValueSnapShot));
+        cloned.children.forEach((row: any, i: number) => {
+          const same = (result as any).children[i];
+          row.children = expectValueSnapShot.children[i].children;
+          row.constraints = same.constraints;
+          row.value = expectValueSnapShot.children[i].value;
+        });
         expect(result).toEqual({
-          ...JSON.parse(JSON.stringify(expectValueSnapShot)),
+          ...cloned,
+          constraints: userRule.constraints,
         });
       });
       it(`deep path success`, async () => {

--- a/packages/rules/src/factories/rule.ts
+++ b/packages/rules/src/factories/rule.ts
@@ -150,6 +150,7 @@ export function createRule<C = any>(settings: RuleSettings<C>): Rule<C> {
       path,
       fullPath,
       value,
+      constraints,
     };
 
     try {

--- a/packages/rules/src/schemes.ts
+++ b/packages/rules/src/schemes.ts
@@ -9,6 +9,7 @@ export interface ValidationError {
   message: string;
   value?: any;
   children?: ValidationError[];
+  constraints?: any;
 }
 
 export function isValidationError(source: unknown): source is ValidationError {


### PR DESCRIPTION
## 📝 Description

Validation error objects are now accompanied by an expected value object.
This allows for custom error messages to use the expected value used when validating the value.
