### PR TITLE
Feat/dispatch form submit

### DIFF
--- a/.changeset/sharp-worms-beg.md
+++ b/.changeset/sharp-worms-beg.md
@@ -1,0 +1,6 @@
+---
+'@fastkit/vue-form-control': patch
+---
+
+When a VueForm submit is executed, the submit event is now dispatched.
+This allows automatic validation and action handler calls to be performed even when a method is called.

--- a/packages/vue-form-control/src/composables/form.ts
+++ b/packages/vue-form-control/src/composables/form.ts
@@ -172,9 +172,19 @@ export class VueForm extends FormNodeControl {
     provide(FormInjectionKey, this);
   }
 
+  /**
+   * Generates SubmitEvent and dispatches it to the form element
+   *
+   * - If `preventDefault()` is called by the event handler, the sending process is canceled
+   */
   submit() {
     const form = this._formRef.value;
-    if (form) {
+    if (!form) return;
+    const ev = new SubmitEvent('submit', {
+      cancelable: true,
+      bubbles: true,
+    });
+    if (form.dispatchEvent(ev)) {
       form.submit();
     }
   }


### PR DESCRIPTION
## 📝 Description

When a VueForm submit is executed, the submit event is now dispatched.
This allows automatic validation and action handler calls to be performed even when a method is called.
