### PR TITLE
Fix preserveOrder behavior in FormSelectorControl

### DIFF
--- a/.changeset/eight-pandas-own.md
+++ b/.changeset/eight-pandas-own.md
@@ -1,0 +1,12 @@
+---
+'@fastkit/vue-form-control': patch
+---
+
+Fix preserveOrder behavior in FormSelectorControl
+
+The preserveOrder property behavior was inverted from the intended specification:
+
+- `preserveOrder: false` (default) now maintains user selection order
+- `preserveOrder: true` now sorts by items order
+
+This is a breaking change that corrects the behavior to match the intended specification.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
        TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install
         uses: ./.github/composite-actions/install
@@ -58,13 +58,13 @@ jobs:
       #   # You can do something when a publish happens.
       #   run: my-slack-bot send-notification --message "A new version of ${GITHUB_REPOSITORY} was published!"
       - name: Setup Pages
-        uses: actions/configure-pages@v2
+        uses: actions/configure-pages@v5
       - name: Build docs
         run: pnpm build:docs
       - name: Upload docs artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: apps/docs/dist/client/
       - name: Deploy docs to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4

--- a/packages/vue-form-control/src/__tests__/selector-integration.test.ts
+++ b/packages/vue-form-control/src/__tests__/selector-integration.test.ts
@@ -157,32 +157,32 @@ function mountSelector(
 
 describe('FormSelectorControl Vue Integration Tests', () => {
   describe('preserveOrder=false (default behavior)', () => {
-    it('should sort selected items by items array order', async () => {
+    it('should maintain user selection order', async () => {
       const { wrapper, control } = mountSelector();
 
       // Select in reverse order
       await wrapper.setProps({ modelValue: ['item4', 'item2', 'item1'] });
       await nextTick();
 
-      // Should be sorted by items array order
+      // Should preserve user selection order
       expect(control.selectedPropItems.map((item) => item.value)).toEqual([
-        'item1',
-        'item2',
         'item4',
+        'item2',
+        'item1',
       ]);
 
       expect(control.preserveOrder).toBe(false);
     });
 
-    it('should maintain items order even with dynamic selection changes', async () => {
+    it('should maintain user selection order even with dynamic selection changes', async () => {
       const { wrapper, control } = mountSelector();
 
       // Initial selection
       await wrapper.setProps({ modelValue: ['item3', 'item1'] });
       await nextTick();
       expect(control.selectedPropItems.map((item) => item.value)).toEqual([
-        'item1',
         'item3',
+        'item1',
       ]);
 
       // Additional selection
@@ -191,9 +191,9 @@ describe('FormSelectorControl Vue Integration Tests', () => {
       });
       await nextTick();
       expect(control.selectedPropItems.map((item) => item.value)).toEqual([
+        'item3',
         'item1',
         'item2',
-        'item3',
       ]);
     });
 
@@ -204,7 +204,7 @@ describe('FormSelectorControl Vue Integration Tests', () => {
       await wrapper.setProps({ modelValue: ['item2', 'item4'] });
       await nextTick();
 
-      // Should be sorted according to items order
+      // Should preserve user selection order
       expect(control.selectedPropItems.map((item) => item.value)).toEqual([
         'item2',
         'item4',
@@ -212,8 +212,8 @@ describe('FormSelectorControl Vue Integration Tests', () => {
     });
   });
 
-  describe('preserveOrder=true (preserve user selection order)', () => {
-    it('should preserve user selection order', async () => {
+  describe('preserveOrder=true (use items order)', () => {
+    it('should sort by items order', async () => {
       const { wrapper, control } = mountSelector(
         { preserveOrder: true },
         { defaultPreserveOrder: true },
@@ -223,25 +223,25 @@ describe('FormSelectorControl Vue Integration Tests', () => {
       await wrapper.setProps({ modelValue: ['item4', 'item2', 'item1'] });
       await nextTick();
 
-      // Should preserve selection order
+      // Should be sorted by items order
       expect(control.selectedPropItems.map((item) => item.value)).toEqual([
-        'item4',
-        'item2',
         'item1',
+        'item2',
+        'item4',
       ]);
 
       expect(control.preserveOrder).toBe(true);
     });
 
-    it('should preserve order with dynamic changes', async () => {
+    it('should sort by items order with dynamic changes', async () => {
       const { wrapper, control } = mountSelector({ preserveOrder: true });
 
       // Initial selection
       await wrapper.setProps({ modelValue: ['item3', 'item1'] });
       await nextTick();
       expect(control.selectedPropItems.map((item) => item.value)).toEqual([
-        'item3',
         'item1',
+        'item3',
       ]);
 
       // Order change
@@ -251,8 +251,8 @@ describe('FormSelectorControl Vue Integration Tests', () => {
       await nextTick();
       expect(control.selectedPropItems.map((item) => item.value)).toEqual([
         'item1',
-        'item3',
         'item2',
+        'item3',
       ]);
     });
 
@@ -265,12 +265,12 @@ describe('FormSelectorControl Vue Integration Tests', () => {
       });
       await nextTick();
 
-      // Should completely preserve selection order
+      // Should be sorted by items order
       expect(control.selectedPropItems.map((item) => item.value)).toEqual([
-        'item4',
-        'item3',
-        'item2',
         'item1',
+        'item2',
+        'item3',
+        'item4',
       ]);
     });
   });
@@ -310,8 +310,8 @@ describe('FormSelectorControl Vue Integration Tests', () => {
       ]);
     });
 
-    it('should preserve manual selection order with preserveOrder=true', async () => {
-      const { wrapper, control } = mountSelector({ preserveOrder: true });
+    it('should preserve manual selection order with preserveOrder=false', async () => {
+      const { wrapper, control } = mountSelector({ preserveOrder: false });
 
       // Simulate manual reverse order selection
       await wrapper.setProps({
@@ -319,7 +319,7 @@ describe('FormSelectorControl Vue Integration Tests', () => {
       });
       await nextTick();
 
-      // preserveOrder=true: preserve manual selection order
+      // preserveOrder=false: preserve manual selection order
       expect(control.selectedPropItems.map((item) => item.value)).toEqual([
         'item4',
         'item3',
@@ -376,10 +376,10 @@ describe('FormSelectorControl Vue Integration Tests', () => {
       await wrapper.setProps({ modelValue: ['item2', 'item1'] });
       await nextTick();
 
-      // Verify initial selection order is preserved
+      // Verify initial selection order is sorted by items order
       expect(control.selectedPropItems.map((item) => item.value)).toEqual([
-        'item2',
         'item1',
+        'item2',
       ]);
 
       // Execute selectAll() - this should reorder to items order regardless of preserveOrder
@@ -423,13 +423,13 @@ describe('FormSelectorControl Vue Integration Tests', () => {
       await wrapper.setProps({ modelValue: ['item2', 'item1'] });
       await nextTick();
 
-      // Both selectedValues and selectedPropItems should be sorted by items order
+      // Both selectedValues and selectedPropItems should preserve user selection order
       // because preserveOrder=false (default)
-      expect(control.selectedValues).toEqual(['item1', 'item2']);
+      expect(control.selectedValues).toEqual(['item2', 'item1']);
       expect(control.selectedPropItems.map((item) => item.value)).toEqual([
-        'item1',
         'item2',
-      ]); // Sorted because preserveOrder=false
+        'item1',
+      ]); // Preserve user order because preserveOrder=false
     });
 
     it('should react to items changes correctly', async () => {
@@ -463,11 +463,11 @@ describe('FormSelectorControl Vue Integration Tests', () => {
       });
 
       await nextTick();
-      // preserveOrder=false: items order
+      // preserveOrder=false: user selection order
       expect(control1.selectedPropItems.map((item) => item.value)).toEqual([
+        'item4',
         'item1',
         'item2',
-        'item4',
       ]);
 
       // Case of preserveOrder=true
@@ -477,11 +477,11 @@ describe('FormSelectorControl Vue Integration Tests', () => {
       });
 
       await nextTick();
-      // preserveOrder=true: preserve selection order
+      // preserveOrder=true: items order
       expect(control2.selectedPropItems.map((item) => item.value)).toEqual([
-        'item4',
         'item1',
         'item2',
+        'item4',
       ]);
     });
   });
@@ -555,7 +555,7 @@ describe('FormSelectorControl Vue Integration Tests', () => {
 
   describe('complex selection scenarios', () => {
     it('should handle complex order preservation scenario', async () => {
-      const { wrapper, control } = mountSelector({ preserveOrder: true });
+      const { wrapper, control } = mountSelector({ preserveOrder: false }); // User selection order
 
       // Simulate gradual selection changes
       // 1. Initial selection
@@ -594,7 +594,7 @@ describe('FormSelectorControl Vue Integration Tests', () => {
         'item4',
       ]);
 
-      // 5. Change order
+      // 5. Change order - should preserve user selection order
       await wrapper.setProps({
         modelValue: ['item4', 'item1', 'item3', 'item2'],
       });

--- a/packages/vue-form-control/src/composables/selector.ts
+++ b/packages/vue-form-control/src/composables/selector.ts
@@ -134,7 +134,7 @@ export function createFormSelectorProps(
         default: () => [],
       },
       /**
-       * Preserve the order of selection values
+       * When true, maintains items order. When false (default), maintains user selection order.
        */
       preserveOrder: {
         type: Boolean,
@@ -193,7 +193,7 @@ export class FormSelectorControl extends FormNodeControl<FormSelectorValue> {
   readonly parentNodeType?: FormNodeType;
 
   /**
-   * Whether to preserve the order of selection values
+   * When true, maintains items order. When false (default), maintains user selection order.
    */
   readonly preserveOrder: boolean;
 
@@ -397,12 +397,12 @@ export class FormSelectorControl extends FormNodeControl<FormSelectorValue> {
 
     this._selectedPropItems = computed(() => {
       const { selectedValues, loadedItems } = this;
-      if (!this.preserveOrder) {
+      if (this.preserveOrder) {
         return loadedItems.filter(
           ({ value }) => value != null && selectedValues.includes(value),
         );
       }
-      // preserveOrder が true の場合、選択値の順序を保持
+      // preserveOrder が false の場合、選択値の順序を保持
       const result: ResolvedFormSelectorItem[] = [];
       selectedValues.forEach((selectedValue) => {
         const item = loadedItems.find(({ value }) => value === selectedValue);
@@ -568,8 +568,8 @@ export class FormSelectorControl extends FormNodeControl<FormSelectorValue> {
         }
       });
 
-      if (this.preserveOrder) {
-        // preserveOrder=true: preserve existing order
+      if (!this.preserveOrder) {
+        // preserveOrder=false: preserve existing order
 
         // 1. Add existing values that are currently selected, preserving their order
         currentValues.forEach((value) => {
@@ -604,7 +604,7 @@ export class FormSelectorControl extends FormNodeControl<FormSelectorValue> {
 
         this._currentValue.value = values;
       } else {
-        // preserveOrder=false: use items order (original behavior)
+        // preserveOrder=true: use items order (original behavior)
         this.items.forEach((item) => {
           const { propValue } = item;
           if (
@@ -659,8 +659,8 @@ export class FormSelectorControl extends FormNodeControl<FormSelectorValue> {
         ? []
         : [_value];
 
-    // preserveOrder が false の場合は、loadedItems の順序に従って並び替える
-    if (!this.preserveOrder && this._loadedItems?.value) {
+    // preserveOrder が true の場合は、loadedItems の順序に従って並び替える
+    if (this.preserveOrder && this._loadedItems?.value) {
       const loadedValues = this._loadedItems.value.map((item) => item.value);
       return loadedValues.filter((value) => values.includes(value));
     }


### PR DESCRIPTION
Fix preserveOrder behavior in FormSelectorControl

The preserveOrder property behavior was inverted from the intended specification:

- `preserveOrder: false` (default) now maintains user selection order
- `preserveOrder: true` now sorts by items order

This is a breaking change that corrects the behavior to match the intended specification.
