### PR TITLE
Fix activator element handling for non-HTMLElement nodes

### DIFF
--- a/.changeset/green-chefs-watch.md
+++ b/.changeset/green-chefs-watch.md
@@ -1,0 +1,9 @@
+---
+'@fastkit/vue-stack': patch
+---
+
+#### Bug Fixes
+
+- **refElement:** Fixed an issue where `beforeEl?.removeAttribute is not a function` error could occur when the activator element's `$el` was not an `HTMLElement` (e.g., Comment node, Text node, or Proxy instance).
+
+- **withDirectives:** Fixed an issue where "Runtime directive used on component with non-element root node" warning occurred when the activator slot returned a component VNode instead of an element VNode. Component VNodes are now wrapped with a `<div style="display: contents">` to ensure directives work correctly.

--- a/apps/docs/src/pages/vui/index/index.tsx
+++ b/apps/docs/src/pages/vui/index/index.tsx
@@ -38,6 +38,7 @@ export default defineComponent({
   setup() {
     const opened = ref(false);
     const shouldRenderMenu = ref(false);
+    const isDisabledReasonButtonDisabled = ref(true);
     const EXAMPLES = [
       '30569309025904',
       '4000056655665556',
@@ -177,6 +178,43 @@ export default defineComponent({
 
     return () => (
       <div>
+        {/* Test: VMenu with disabledReason button as activator */}
+        <div
+          style={{
+            marginBottom: '20px',
+            padding: '10px',
+            background: '#f5f5f5',
+          }}>
+          <h3>disabled-reason + VMenu Test</h3>
+          <VSwitch v-model={isDisabledReasonButtonDisabled.value}>
+            Disabled
+          </VSwitch>
+          <div style={{ marginTop: '10px' }}>
+            <VMenu
+              v-slots={{
+                activator: ({ attrs }) => (
+                  <VButton
+                    {...attrs}
+                    disabled={isDisabledReasonButtonDisabled.value}
+                    disabledReason="この機能は現在利用できません">
+                    Open Menu
+                  </VButton>
+                ),
+                default: () => (
+                  <div style={{ padding: '10px' }}>
+                    <p>Menu Content 1</p>
+                    <p>Menu Content 2</p>
+                    <p>Menu Content 3</p>
+                  </div>
+                ),
+              }}
+            />
+            <span style={{ marginLeft: '10px' }}>
+              ← disabled時はホバーで理由表示、enabled時はクリックでメニュー表示
+            </span>
+          </div>
+        </div>
+
         <VSwitch v-model={shouldRenderMenu.value}>renderMenu</VSwitch>
         {shouldRenderMenu.value && (
           <VMenu

--- a/packages/vue-stack/src/composables/control.tsx
+++ b/packages/vue-stack/src/composables/control.tsx
@@ -1204,10 +1204,11 @@ export function useStackControl(
 function refElement<T extends object | undefined>(
   obj: T,
 ): HTMLElement | undefined {
-  return (
-    (obj && '$el' in obj ? (obj.$el as HTMLElement) : (obj as HTMLElement)) ||
-    undefined
-  );
+  const el = obj && '$el' in obj ? obj.$el : obj;
+  if (el instanceof HTMLElement) {
+    return el;
+  }
+  return undefined;
 }
 
 function getActivator(

--- a/packages/vue-stack/src/composables/control.tsx
+++ b/packages/vue-stack/src/composables/control.tsx
@@ -8,6 +8,7 @@ import {
   Teleport,
   watch,
   ref,
+  h,
   VNode,
   withDirectives,
   vShow,
@@ -998,7 +999,15 @@ export function useStackControl(
             dirs.push(_clickOutside);
           }
 
-          $child = withDirectives(node, dirs);
+          // If node is a component (not an element), wrap it with a div
+          // to avoid "Runtime directive used on component with non-element root node" warning
+          const isElementNode =
+            typeof node.type === 'string' || node.type === undefined;
+          const targetNode = isElementNode
+            ? node
+            : h('div', { style: { display: 'contents' } }, [node]);
+
+          $child = withDirectives(targetNode, dirs);
 
           const _props: Record<string, any> = {
             class: control.classes,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request !

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> Add a brief description

- Fixed `beforeEl?.removeAttribute is not a function` error that occurred when activator element's `$el` was not an `HTMLElement`          
- Fixed "Runtime directive used on component with non-element root node" warning when activator slot returned a component VNode

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

### `refElement` function

The function now properly checks `instanceof HTMLElement` before returning. This prevents errors when `$el` is a Comment node, Text node,  or Proxy instance (which can happen with Vue 3's Fragment support).

### `withDirectives` handling

When the activator slot returns a component VNode instead of an element VNode, it is now wrapped with `<div style="display: contents">` to ensure directives work correctly without affecting layout.

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Fastkit users. -->
No

## 📝 Additional Information

### Test Plan
                                                                                                                                      
- [x] Verified error no longer occurs with disabled buttons using `disabledReason` prop                                                    
- [x] Verified warning no longer appears for component-based activators

### Confirming errors in `localhost:3000/fastkit/vui` in an unmodified state

<img width="617" height="73" alt="スクリーンショット 2026-01-28 12 02 05" src="https://github.com/user-attachments/assets/41c3e66a-0fa3-4cde-b087-cdde623834ba" />
