### PR TITLE
feat: Add current z-index css custom property

### DIFF
--- a/.changeset/weak-actors-slide.md
+++ b/.changeset/weak-actors-slide.md
@@ -1,0 +1,5 @@
+---
+'@fastkit/vue-stack': patch
+---
+
+The CSS custom property `--v-stack-current-z-index`, indicating the current z-index, is added to the document root.

--- a/packages/vue-stack/src/composables/control.tsx
+++ b/packages/vue-stack/src/composables/control.tsx
@@ -674,7 +674,10 @@ export function useStackControl(
       }
     },
     setNeedRender(needRender: boolean) {
-      if (!needRender) state.activateOrder = 0;
+      if (!needRender) {
+        state.activateOrder = 0;
+        $vstack.updateCurrentZIndexVar();
+      }
       state.needRender = alwaysRender.value || needRender;
     },
     outsideClickCloseConditional(ev, pre) {
@@ -933,6 +936,7 @@ export function useStackControl(
       const front = $vstack.getFront();
       const maxActivateOrder = front ? front.activateOrder : 0;
       state.activateOrder = maxActivateOrder + 1;
+      $vstack.updateCurrentZIndexVar();
     },
 
     isFront(filter?: (control: VStackControl) => boolean) {

--- a/packages/vue-stack/src/service.ts
+++ b/packages/vue-stack/src/service.ts
@@ -137,6 +137,21 @@ export class VueStackService {
   }
 
   /**
+   * Update the `--v-stack-current-z-index` CSS custom property on
+   * `document.documentElement` to reflect the z-index of the frontmost
+   * active stack.
+   */
+  updateCurrentZIndexVar() {
+    if (typeof document === 'undefined') return;
+    const front = this.getFront();
+    const maxActivateOrder = front ? front.activateOrder : 0;
+    document.documentElement.style.setProperty(
+      '--v-stack-current-z-index',
+      String(this.zIndex + maxActivateOrder),
+    );
+  }
+
+  /**
    * Check if the specified stack is currently displayed in the foreground
    *
    * @param control - The stack to check


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request !

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> Add a brief description

Add a CSS custom property so that applications can utilize the current z-index of the vue-stack.

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

The CSS custom property `--v-stack-current-z-index`, indicating the current z-index, is added to the document root.

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Fastkit users. -->

## 📝 Additional Information
