### PR TITLE
Feat/support import with layer

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -89,6 +89,7 @@
     "open-bushes-flash",
     "ready-monkeys-obey",
     "salty-tigers-find",
+    "shaky-crabs-shout",
     "spicy-comics-lose",
     "tiny-mangos-exist",
     "tired-walls-punch",

--- a/.changeset/shaky-crabs-shout.md
+++ b/.changeset/shaky-crabs-shout.md
@@ -1,0 +1,5 @@
+---
+'@fastkit/plugboy': patch
+---
+
+Updated the regular expression in `preserve-css-imports.ts` to support import with layer

--- a/packages/plugboy/CHANGELOG.md
+++ b/packages/plugboy/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @fastkit/plugboy
 
+## 1.0.0-next.4
+
+### Patch Changes
+
+- Updated the regular expression in `preserve-css-imports.ts` to support import with layer
+
 ## 1.0.0-next.3
 
 ### Patch Changes

--- a/packages/plugboy/package.json
+++ b/packages/plugboy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastkit/plugboy",
-  "version": "1.0.0-next.3",
+  "version": "1.0.0-next.4",
   "description": "",
   "keywords": [],
   "repository": {

--- a/packages/plugboy/src/types/workspace.ts
+++ b/packages/plugboy/src/types/workspace.ts
@@ -122,6 +122,7 @@ export interface ResolvedWorkspaceConfig
         | 'hooks'
         | 'plugins'
         | 'dts'
+        | 'css'
         | 'optimizeCSS'
         | TSDownSyncOption
       >
@@ -148,6 +149,7 @@ export interface ResolvedWorkspaceConfig
    * @see {@link DTSSettings}
    */
   dts?: DTSSettings;
+  css?: CssOptions;
   /**
    * CSS optimization options
    *

--- a/packages/plugboy/src/workspace/plugins/preserve-css-imports.ts
+++ b/packages/plugboy/src/workspace/plugins/preserve-css-imports.ts
@@ -11,7 +11,7 @@ import { definePlugin } from '../../utils';
  */
 
 /**
- * Regular expression for CSS @import
+ * Regular expression for CSS @import (with optional layer() support)
  *
  * Supports the following patterns:
  * - @import 'path';
@@ -19,13 +19,28 @@ import { definePlugin } from '../../utils';
  * - @import url(path);
  * - @import url('path');
  * - @import url("path");
+ * - @import url('path') layer(name);
+ * - @import 'path' layer(name);
+ *
+ * Captures:
+ *   1: import path
+ *   2: layer specification (e.g. " layer(fabric.foundation)") or undefined
  */
 const EXTERNAL_IMPORT_REGEX =
-  /@import\s+(?:url\(\s*['"]?|['"])([^'"\s);]+)(?:['"]?\s*\)|['"])\s*;/g;
+  /@import\s+(?:url\(\s*['"]?|['"])([^'"\s);]+)(?:['"]?\s*\)|['"])(\s+layer\([^)]+\))?\s*;/g;
+
+interface ExternalCssImport {
+  path: string;
+  layer?: string;
+}
+
+function externalImportKey(entry: ExternalCssImport): string {
+  return entry.layer ? `${entry.path}::${entry.layer}` : entry.path;
+}
 
 export function createPreserveCssImportsPlugin() {
-  // Collect external CSS import paths (using Set to avoid duplicates)
-  const externalCssImports = new Set<string>();
+  // Collect external CSS imports (using Map keyed by path+layer to avoid duplicates)
+  const externalCssImports = new Map<string, ExternalCssImport>();
 
   return definePlugin({
     name: 'preserve-css-imports',
@@ -40,11 +55,15 @@ export function createPreserveCssImportsPlugin() {
         let hasExternalImports = false;
         const transformed = code.replace(
           EXTERNAL_IMPORT_REGEX,
-          (match, importPath: string) => {
+          (match, importPath: string, layerSpec?: string) => {
             // If not a relative path (./) or absolute path (/), treat as package reference from node_modules
             if (!importPath.startsWith('.') && !importPath.startsWith('/')) {
               hasExternalImports = true;
-              externalCssImports.add(importPath);
+              const entry: ExternalCssImport = {
+                path: importPath,
+                layer: layerSpec?.trim(),
+              };
+              externalCssImports.set(externalImportKey(entry), entry);
               // Remove @import (replace with empty string)
               return '';
             }
@@ -65,8 +84,10 @@ export function createPreserveCssImportsPlugin() {
           return;
         }
 
-        const importStatements = Array.from(externalCssImports)
-          .map((path) => `@import '${path}';`)
+        const importStatements = Array.from(externalCssImports.values())
+          .map(({ path, layer }) =>
+            layer ? `@import '${path}' ${layer};` : `@import '${path}';`,
+          )
           .join('\n');
 
         for (const chunk of Object.values(bundle)) {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request !

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> Add a brief description

Fixed an issue where CSS `@import` statements with `layer()` specification were silently dropped from build output because the `preserve-css-imports` plugin's regex did not match the `@import url('...') layer(...);` pattern.

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

- `EXTERNAL_IMPORT_REGEX` in `preserve-css-imports` does not match `@import url('...') layer(...);`
- `@import` with `layer()` is not detected as an external import, causing rolldown to attempt resolution and silently drop it
- `generateBundle` re-inserts imports as `@import 'path';` only, losing the `layer()` information

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

- Added an optional capture group for `layer()` to the regex so it matches `@import url('...') layer(...);`
- `layer()` information is preserved during `transform` and correctly re-inserted as `@import 'path' layer(...);` in `generateBundle`
- No impact on existing `@import` statements without `layer()`

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Fastkit users. -->

No

## 📝 Additional Information

CSS Cascade Layers (`@import ... layer()`) is part of the CSS specification and widely supported in modern browsers.
This change extends the existing `preserve-css-imports` mechanism as a workaround for tsdown/rolldown's Lightning CSS not being able to process the `layer()` syntax in `@import` statements.