### PR TITLE
fix(@fastkit/vue-stack): VMenu outer scroller not shrinking when inner content height decreases

### DIFF
--- a/.changeset/fix-vmenu-resize-measure-order.md
+++ b/.changeset/fix-vmenu-resize-measure-order.md
@@ -1,0 +1,5 @@
+---
+'@fastkit/vue-stack': patch
+---
+
+Fix `VMenu` not resizing its outer scroller when the inner content shrinks (e.g. collapsing an accordion or hiding nodes with `v-show`). `updateMenuRect` now clears the content element's fixed inline size before calling `getBoundingClientRect`, so the body's natural size is measured instead of the constrained one — previously the measurement was taken before the styles were cleared, leaving stale dimensions that prevented the scroller from shrinking.

--- a/apps/docs/src/pages/vui/index/index.tsx
+++ b/apps/docs/src/pages/vui/index/index.tsx
@@ -39,6 +39,7 @@ export default defineComponent({
     const opened = ref(false);
     const shouldRenderMenu = ref(false);
     const isDisabledReasonButtonDisabled = ref(true);
+    const isResizeMenuExpanded = ref(false);
     const EXAMPLES = [
       '30569309025904',
       '4000056655665556',
@@ -211,6 +212,49 @@ export default defineComponent({
             />
             <span style={{ marginLeft: '10px' }}>
               ← disabled時はホバーで理由表示、enabled時はクリックでメニュー表示
+            </span>
+          </div>
+        </div>
+
+        {/* Test: VMenu resize tracking when inner content height changes */}
+        <div
+          style={{
+            marginBottom: '20px',
+            padding: '10px',
+            background: '#f5f5f5',
+          }}>
+          <h3>VMenu resize tracking Test</h3>
+          <div>
+            <VMenu
+              v-slots={{
+                activator: ({ attrs }) => (
+                  <VButton {...attrs}>Open Resizable Menu</VButton>
+                ),
+                default: () => (
+                  <div style={{ padding: '10px', width: '240px' }}>
+                    <VButton
+                      onClick={() => {
+                        isResizeMenuExpanded.value =
+                          !isResizeMenuExpanded.value;
+                      }}>
+                      {isResizeMenuExpanded.value ? 'Collapse' : 'Expand'}
+                    </VButton>
+                    <div
+                      v-show={isResizeMenuExpanded.value}
+                      style={{
+                        marginTop: '10px',
+                        height: '300px',
+                        background: 'skyblue',
+                      }}>
+                      動的に出し入れされる大きい要素
+                    </div>
+                    <p>末尾の固定行</p>
+                  </div>
+                ),
+              }}
+            />
+            <span style={{ marginLeft: '10px' }}>
+              ← Expand/Collapseでメニュー外枠の高さが追従するか確認
             </span>
           </div>
         </div>

--- a/apps/docs/src/pages/vui/index/index.tsx
+++ b/apps/docs/src/pages/vui/index/index.tsx
@@ -10,7 +10,36 @@ import {
   VButton,
   VSwitch,
 } from '@fastkit/vui';
+import { defineMenuComponent } from '@fastkit/vue-stack';
 import { range } from '@fastkit/helpers';
+
+// Test-only menu component that mimics consumers (e.g. Fabric's UIMenu)
+// whose body conforms to the scroller's clamped height.
+// `min-height: 100%` makes the body match the scroller height whenever the
+// inner content is smaller — the exact condition that triggers the
+// resize-measure-order bug after collapsing previously-expanded content.
+// (Using `min-height` instead of `height: 100%` so that during the expanded
+// state the body still grows with its content and keeps a solid background
+// behind the overflowing rows.)
+const VMenuResizeTest = defineMenuComponent({
+  name: 'VMenuResizeTest',
+  attrs: { class: 'v-menu' },
+  setup(ctx) {
+    ctx.setupContext.expose({ menu: ctx });
+    return (children) => (
+      <div
+        style={{
+          display: 'block',
+          minHeight: '100%',
+          background: '#fff',
+          boxSizing: 'border-box',
+        }}
+        {...ctx.attrs}>
+        {children}
+      </div>
+    );
+  },
+});
 
 function Test(attrs: any = {}) {
   return (
@@ -216,7 +245,12 @@ export default defineComponent({
           </div>
         </div>
 
-        {/* Test: VMenu resize tracking when inner content height changes */}
+        {/* Test: VMenu resize tracking when inner content height changes.
+            Reproduces the bug observed in consumers whose menu body conforms
+            to the scroller's clamped height. Open the menu, click Expand to
+            reveal a tall block (forces max-height clamping / scrollable),
+            then click Collapse — without the fix, the scroller keeps the
+            phantom scrollable area instead of shrinking back. */}
         <div
           style={{
             marginBottom: '20px',
@@ -225,13 +259,18 @@ export default defineComponent({
           }}>
           <h3>VMenu resize tracking Test</h3>
           <div>
-            <VMenu
+            <VMenuResizeTest
+              maxHeight={250}
               v-slots={{
-                activator: ({ attrs }) => (
+                activator: ({ attrs }: any) => (
                   <VButton {...attrs}>Open Resizable Menu</VButton>
                 ),
                 default: () => (
-                  <div style={{ padding: '10px', width: '240px' }}>
+                  <div
+                    style={{
+                      padding: '10px',
+                      width: '280px',
+                    }}>
                     <VButton
                       onClick={() => {
                         isResizeMenuExpanded.value =
@@ -239,22 +278,27 @@ export default defineComponent({
                       }}>
                       {isResizeMenuExpanded.value ? 'Collapse' : 'Expand'}
                     </VButton>
-                    <div
-                      v-show={isResizeMenuExpanded.value}
-                      style={{
-                        marginTop: '10px',
-                        height: '300px',
-                        background: 'skyblue',
-                      }}>
-                      動的に出し入れされる大きい要素
+                    <div v-show={isResizeMenuExpanded.value}>
+                      {range(40, 1).map((n) => (
+                        <p
+                          key={n}
+                          style={{
+                            margin: '6px 0',
+                            padding: '4px 8px',
+                            background: 'rgba(135, 206, 235, 0.3)',
+                          }}>
+                          Expanded row {n}
+                        </p>
+                      ))}
                     </div>
-                    <p>末尾の固定行</p>
+                    <p style={{ marginTop: '10px' }}>末尾の固定行</p>
                   </div>
                 ),
               }}
             />
             <span style={{ marginLeft: '10px' }}>
-              ← Expand/Collapseでメニュー外枠の高さが追従するか確認
+              ← Expand→Collapse でメニュー外枠が縮むか確認（修正前は phantom
+              スクロール領域が残る）
             </span>
           </div>
         </div>

--- a/packages/vue-stack/src/components/VMenu.tsx
+++ b/packages/vue-stack/src/components/VMenu.tsx
@@ -1059,13 +1059,13 @@ export function defineMenuComponent<
         const originalMaxWidth = content.style.maxWidth;
         const originalMaxHeight = content.style.maxHeight;
 
-        const rect = body.getBoundingClientRect();
-
         content.style.display = '';
         content.style.width = '';
         content.style.height = '';
         content.style.maxWidth = '';
         content.style.maxHeight = '';
+
+        const rect = body.getBoundingClientRect();
 
         content.style.display = originalDisplay;
         content.style.width = originalWidth;


### PR DESCRIPTION
Closes #

## 📝 Description

Fixes a bug in `@fastkit/vue-stack` where `VMenu`'s outer scroller would not shrink back when the inner content height decreased after the menu was opened (e.g. collapsing an accordion, toggling DOM with `v-show`, or changes in the number of search results). The scroller stayed fixed at the previous height, leaving wasted empty space and a scrollable area below the items.

## ⛳️ Current behavior (updates)

Inside `VMenu`, `updateMenuRect` targets `contentRef` (the scroller), which receives a fixed `width`/`height` inline style on every render via `_styles.value`. The intended behavior was to "temporarily clear the fixed inline styles, measure the body's natural size, then immediately restore the styles." However, the actual order is:

1. Save `originalDisplay` etc.
2. `body.getBoundingClientRect()` ← **measured while the fixed style is still applied**
3. Clear the styles
4. Immediately restore the styles

As a result, even when the inner DOM shrinks, the measured `rect` is capped at the previous scroller size, `state.rect.height` is never updated, and the scroller's fixed height stays as-is — so the empty space remains even after collapsing.

## 🚀 New behavior

The processing order in `updateMenuRect` has been corrected to what was presumably originally intended: **(1) save originals → (2) clear styles → (3) measure → (4) restore**. With this change, `body.getBoundingClientRect()` is no longer affected by the fixed inline styles and returns the natural size, so the scroller now correctly tracks shrinkage of the inner content.

In addition, a manual verification sample has been added to `apps/docs/src/pages/vui/index/index.tsx` (a `VMenu` that toggles a 300px-tall region via `v-show`).

### Verification steps

1. Start the docs with `pnpm dev`
2. In the "VMenu resize tracking Test" block at the top of `/vui`, click `Open Resizable Menu`
3. Click `Expand` to reveal the skyblue region, then `Collapse` to hide it again
4. Confirm that the menu's outer height shrinks accordingly (before this fix it would not shrink)

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

- The internal `ResizeObserver` target (the menu inner) is correct as-is and is not changed in this PR (the bug is on the measurement function side)
- The behavior of `ResizeObserver` / `getBoundingClientRect` is hard to reproduce in jsdom, so no automated tests have been added

🤖 Generated with [Claude Code](https://claude.com/claude-code)