### PR TITLE
fix(universal-logger): widen @datadog/browser-logs peer dependency range

### DIFF
--- a/.changeset/datadog-peer-range.md
+++ b/.changeset/datadog-peer-range.md
@@ -1,0 +1,5 @@
+---
+"@fastkit/universal-logger": patch
+---
+
+Widen the `@datadog/browser-logs` peer dependency range to `^5.8.0 || ^6.0.0 || ^7.0.0` so it matches the version actually built against (`7.4.0`). Previously the peer range only allowed `^5.8.0`, which excluded the v6/v7 majors used in development and emitted spurious peer warnings for consumers on newer versions. The used API surface (`init`, `logger[level]` with the `error` argument) is present across all of these majors.

--- a/.changeset/datadog-peer-range.md
+++ b/.changeset/datadog-peer-range.md
@@ -1,5 +1,0 @@
----
-"@fastkit/universal-logger": patch
----
-
-Widen the `@datadog/browser-logs` peer dependency range to `^5.8.0 || ^6.0.0 || ^7.0.0` so it matches the version actually built against (`7.4.0`). Previously the peer range only allowed `^5.8.0`, which excluded the v6/v7 majors used in development and emitted spurious peer warnings for consumers on newer versions. The used API surface (`init`, `logger[level]` with the `error` argument) is present across all of these majors.

--- a/packages/universal-logger/CHANGELOG.md
+++ b/packages/universal-logger/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @fastkit/universal-logger
 
+## 0.17.2
+
+### Patch Changes
+
+- [`5b5e3dc`](https://github.com/dadajam4/fastkit/commit/5b5e3dc642ea6cf0a92ecda1d0f4bce66ff83127) Thanks [@dadajam4](https://github.com/dadajam4)! - Widen the `@datadog/browser-logs` peer dependency range to `^5.8.0 || ^6.0.0 || ^7.0.0` so it matches the version actually built against (`7.4.0`). Previously the peer range only allowed `^5.8.0`, which excluded the v6/v7 majors used in development and emitted spurious peer warnings for consumers on newer versions. The used API surface (`init`, `logger[level]` with the `error` argument) is present across all of these majors.
+
 ## 0.17.1
 
 ### Patch Changes

--- a/packages/universal-logger/package.json
+++ b/packages/universal-logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastkit/universal-logger",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "Pluggable and universal log output library for any server/browser execution environment.",
   "keywords": [
     "fastkit",

--- a/packages/universal-logger/package.json
+++ b/packages/universal-logger/package.json
@@ -61,7 +61,7 @@
     "@datadog/browser-logs": "^7.4.0"
   },
   "peerDependencies": {
-    "@datadog/browser-logs": "^5.8.0"
+    "@datadog/browser-logs": "^5.8.0 || ^6.0.0 || ^7.0.0"
   },
   "peerDependenciesMeta": {
     "@datadog/browser-logs": {


### PR DESCRIPTION
## 概要

`@fastkit/universal-logger` の `@datadog/browser-logs` peerDependencies レンジを、実際にビルド対象となっているバージョン（`7.4.0`）に整合させます。

## 背景 / 問題

- `devDependencies`: `@datadog/browser-logs` は `^7.4.0`
- `peerDependencies`: `@datadog/browser-logs` は `^5.8.0`

peer レンジが `^5.8.0`（5系のみ）だったため、開発・ビルドで使っている v6/v7 をカバーしておらず、新しいバージョンを使う利用者に不要な peer 警告が出ていました。git 履歴を確認したところ、この `^5.8.0` は過去に「peer を当時の devDeps に合わせる」機械的更新（`3952dc10`）で設定された値で、devDeps が 7 系に上がった際に追従漏れしていたものでした。

## 変更内容

peer レンジを `^5.8.0 || ^6.0.0 || ^7.0.0` に拡大。

```diff
  "peerDependencies": {
-   "@datadog/browser-logs": "^5.8.0"
+   "@datadog/browser-logs": "^5.8.0 || ^6.0.0 || ^7.0.0"
  },
```

## 互換性の検証

実際に使用している API（`transports/datadog.ts`）が 5.8.0 / 7.4.0 の両端で揃っていることを、各バージョンの型定義を取得して確認済み:

| 使用箇所 | 5.8.0 | 7.4.0 |
|---|---|---|
| `datadogLogs` エクスポート | ✅ | ✅ |
| `LogsInitConfiguration` 型 | ✅ | ✅ |
| `init(config)` / `forwardErrorsToLogs` | ✅ | ✅ |
| `logger[level](message, context, error)`（第3引数 error） | ✅ | ✅ |

両端で揃っているため、間の v6 系も含めて全メジャーで互換です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)