### PR TITLE
fix(plugboy): silence spurious UNRESOLVED_IMPORT and SOURCEMAP_BROKEN build warnings

### DIFF
--- a/.changeset/plugboy-build-warnings.md
+++ b/.changeset/plugboy-build-warnings.md
@@ -1,0 +1,8 @@
+---
+"@fastkit/plugboy": patch
+---
+
+Silence two classes of spurious build warnings so real issues stand out.
+
+- **Self-reference / `deps.neverBundle` imports (`UNRESOLVED_IMPORT`):** imports of the package's own name (e.g. `my-pkg/assets/logo.svg`, resolved at runtime via the `exports` map) and subpaths of packages listed in `deps.neverBundle` are now resolved as explicit externals up front, so rolldown no longer emits `UNRESOLVED_IMPORT` for them. Genuinely unresolved specifiers (typos) still warn, and build output is unchanged.
+- **Empty declaration chunks (`SOURCEMAP_BROKEN`):** `rolldown-plugin-dts`'s fake-js pass returns a source-map-less string for empty `.d.ts` chunks (e.g. an entry composed solely of external re-exports), which made rolldown emit a spurious `SOURCEMAP_BROKEN` warning. This warning is now filtered — but only when attributed to `rolldown-plugin-dts:fake-js`; genuine JS-chunk sourcemap breakage still warns. The suppression is traceable at debug log level. This is a workaround for an upstream `rolldown-plugin-dts` bug and is documented for removal once fixed upstream.

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 .DS_Store
 *.log
 .tmp
+.tmp-plugboy-e2e-*
+.tmp-plugboy-dts-*
 vitest.config.ts.timestamp-*
 vite.config.ts.timestamp-*
 *.bundled_*.mjs

--- a/packages/debounce/src/debounce.ts
+++ b/packages/debounce/src/debounce.ts
@@ -100,14 +100,14 @@ export function debounce<FN extends AnyFunction = AnyFunction>(
   handler: FN,
   delay?: number,
   immediate?: boolean,
-): Debounced<FN>; // eslint-disable-line prettier/prettier
+): Debounced<FN>;
 export function debounce<FN extends AnyFunction = AnyFunction>(
   handler: FN,
   options: DebounceOptions,
-): Debounced<FN>; // eslint-disable-line prettier/prettier
+): Debounced<FN>;
 export function debounce<FN extends AnyFunction = AnyFunction>(
   setrings: DebounceSettings<FN>,
-): Debounced<FN>; // eslint-disable-line prettier/prettier
+): Debounced<FN>;
 
 export function debounce<FN extends AnyFunction = AnyFunction>(
   fnOrSettings: FN | DebounceSettings<FN>,

--- a/packages/plugboy/README-ja.md
+++ b/packages/plugboy/README-ja.md
@@ -291,6 +291,20 @@ export default defineWorkspaceConfig({
 });
 ```
 
+### 依存関係の外部化
+
+`deps.neverBundle` は、指定したパッケージをバンドルせず外部依存（external）として
+扱います。マッチングは**パッケージ名とそのサブパス**単位で行われ、`'foo'` を指定
+すると `foo` と `foo/bar` の両方が external になります。
+
+**自己参照（self-reference）は常に自動で external になります。** モジュールが自身の
+パッケージ名で import した場合（例: `import logo from 'my-pkg/assets/logo.svg'`）、
+その import はパッケージ自身の `exports` マップ（`"./*": "./dist/*"`）を通じて
+実行時に解決されるため、バンドルされません。自分自身のパッケージを `neverBundle` に
+列挙する必要はありません。plugboy がこれらを事前に external として解決するため、
+rolldown の `UNRESOLVED_IMPORT` 警告は発生しません。一方、本当に解決できない
+specifier（typo など）は従来どおり警告されます。
+
 ## フック システム
 
 ### ライフサイクルフック

--- a/packages/plugboy/README.md
+++ b/packages/plugboy/README.md
@@ -292,6 +292,20 @@ export default defineWorkspaceConfig({
 });
 ```
 
+### Dependency Externalization
+
+`deps.neverBundle` marks packages as external instead of bundling them. Matching
+is by **package name and its subpaths** — listing `'foo'` externalizes both
+`foo` and `foo/bar`.
+
+**Self-references are always external, automatically.** When a module imports
+its own package by name (e.g. `import logo from 'my-pkg/assets/logo.svg'`), the
+import is served at runtime via the package's own `exports` map
+(`"./*": "./dist/*"`) and is never bundled — you do **not** need to list your own
+package in `neverBundle`. Because plugboy resolves these as external up front,
+they never trigger rolldown's `UNRESOLVED_IMPORT` warning, while genuinely
+unresolved specifiers (typos) still warn as usual.
+
 ## Hook System
 
 ### Lifecycle Hooks

--- a/packages/plugboy/__tests__/dts-sourcemap-warning.build.spec.ts
+++ b/packages/plugboy/__tests__/dts-sourcemap-warning.build.spec.ts
@@ -1,0 +1,103 @@
+import { describe, test, expect, afterAll } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+/**
+ * Integration coverage for the dts SOURCEMAP_BROKEN suppression.
+ *
+ * `rolldown-plugin-dts`'s fake-js pass returns a mapless `"export { };"` string
+ * for empty declaration chunks, which makes rolldown emit a spurious
+ * `[SOURCEMAP_BROKEN]` warning when sourcemaps are enabled. An entry whose
+ * declaration output is empty (e.g. `export {}`, or a package composed solely of
+ * external re-exports) reproduces it.
+ *
+ * Fixtures live under the repo root (outside `packages/**`) and are created and
+ * removed at test time — see `external-imports.build.spec.ts` for the rationale.
+ * Builds run in a child `tsx` process so rolldown's native diagnostics are
+ * captured at the OS level.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+const TSX_BIN = path.join(REPO_ROOT, 'node_modules/.bin/tsx');
+const PLUGBOY_DRIVER = path.join(__dirname, 'helpers/plugboy-build-driver.mts');
+const DTS_DRIVER = path.join(__dirname, 'helpers/dts-sourcemap-driver.mts');
+const ANSI_RE = /\[[0-9;]*m/g;
+const createdDirs: string[] = [];
+
+afterAll(() => {
+  for (const dir of createdDirs) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+/** Create a fixture package whose entry emits an empty declaration file. */
+function emptyDtsFixture(): string {
+  const root = path.join(
+    REPO_ROOT,
+    `.tmp-plugboy-dts-${Date.now()}-${createdDirs.length}`,
+  );
+  const dir = path.join(root, 'pkg');
+  createdDirs.push(root);
+  fs.mkdirSync(path.join(dir, 'src'), { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, 'package.json'),
+    JSON.stringify({
+      name: '@plugboy-e2e/reexport',
+      version: '0.0.0',
+      type: 'module',
+      exports: {
+        '.': { types: './dist/pkg.d.mts', import: './dist/pkg.mjs' },
+        './*': './dist/*',
+      },
+    }),
+  );
+  fs.writeFileSync(
+    path.join(dir, 'plugboy.workspace.ts'),
+    `export default ${JSON.stringify({
+      ignoreProjectConfig: true,
+      entries: { '.': './src/index.ts' },
+    })};\n`,
+  );
+  // An empty type surface → empty .d.ts chunk → fake-js emits `"export { };"`.
+  fs.writeFileSync(path.join(dir, 'src/index.ts'), 'export {};\n');
+  return dir;
+}
+
+function run(driver: string, args: string[], cwd: string): string {
+  const result = spawnSync(TSX_BIN, [driver, ...args], { cwd, encoding: 'utf8' });
+  return `${result.stdout ?? ''}${result.stderr ?? ''}`.replace(ANSI_RE, '');
+}
+
+describe('dts SOURCEMAP_BROKEN suppression (integration)', () => {
+  test('a real plugboy build of an empty-dts package emits no SOURCEMAP_BROKEN', () => {
+    const dir = emptyDtsFixture();
+    const log = run(PLUGBOY_DRIVER, [dir], dir);
+    expect(log).not.toContain('SOURCEMAP_BROKEN');
+    // Sanity: the build actually produced the declaration file.
+    expect(fs.existsSync(path.join(dir, 'dist/pkg.d.mts'))).toBe(true);
+  }, 60_000);
+
+  test('output is byte-identical with and without the suppression plugin', () => {
+    const dir = emptyDtsFixture();
+    run(DTS_DRIVER, [dir, 'out-suppress', 'suppress'], dir);
+    run(DTS_DRIVER, [dir, 'out-plain', 'none'], dir);
+
+    for (const file of ['pkg.d.mts', 'pkg.mjs']) {
+      const a = path.join(dir, 'out-suppress', file);
+      const b = path.join(dir, 'out-plain', file);
+      expect(fs.existsSync(a), `${file} (suppress)`).toBe(true);
+      expect(fs.existsSync(b), `${file} (plain)`).toBe(true);
+      expect(fs.readFileSync(a)).toEqual(fs.readFileSync(b));
+    }
+  }, 60_000);
+
+  test('a genuine JS-chunk sourcemap break is NOT suppressed (still warns)', () => {
+    const dir = emptyDtsFixture();
+    // `js-breaker` mode enables the suppress plugin AND a plugin that breaks the
+    // JS chunk sourcemap — the warning must still surface.
+    const log = run(DTS_DRIVER, [dir, 'out-breaker', 'js-breaker'], dir);
+    expect(log).toContain('SOURCEMAP_BROKEN');
+    expect(log).toContain('js-sourcemap-breaker');
+  }, 60_000);
+});

--- a/packages/plugboy/__tests__/dts-sourcemap-warning.build.spec.ts
+++ b/packages/plugboy/__tests__/dts-sourcemap-warning.build.spec.ts
@@ -65,7 +65,10 @@ function emptyDtsFixture(): string {
 }
 
 function run(driver: string, args: string[], cwd: string): string {
-  const result = spawnSync(TSX_BIN, [driver, ...args], { cwd, encoding: 'utf8' });
+  const result = spawnSync(TSX_BIN, [driver, ...args], {
+    cwd,
+    encoding: 'utf8',
+  });
   return `${result.stdout ?? ''}${result.stderr ?? ''}`.replace(ANSI_RE, '');
 }
 

--- a/packages/plugboy/__tests__/external-imports.build.spec.ts
+++ b/packages/plugboy/__tests__/external-imports.build.spec.ts
@@ -1,0 +1,133 @@
+import { describe, test, expect, afterAll } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+/**
+ * Integration coverage for the external-imports plugin: run a *real* plugboy
+ * build of a generated fixture and assert on the emitted rolldown diagnostics.
+ *
+ * The fixture lives directly under the repo root (not under `packages/**`) so
+ * that pnpm's workspace globs never pick it up as a member and tsdown never
+ * discovers plugboy's own `tsdown.config.ts` as an ancestor. It is created at
+ * test time and removed afterwards, so it is invisible to `pnpm install`,
+ * Turbo and `tsc`. The config is a plain object (no `@fastkit/plugboy` import)
+ * so the build does not depend on plugboy's own `dist` being present.
+ *
+ * The build runs in a child `tsx` process: rolldown writes its diagnostics
+ * straight to the OS stdout/stderr descriptors, so an in-process
+ * `process.stderr.write` override would miss them — only capturing a child
+ * process's output works.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+const TSX_BIN = path.join(REPO_ROOT, 'node_modules/.bin/tsx');
+const DRIVER = path.join(__dirname, 'helpers/plugboy-build-driver.mts');
+const createdDirs: string[] = [];
+
+afterAll(() => {
+  for (const dir of createdDirs) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+const ANSI_RE = /\[[0-9;]*m/g;
+
+interface BuildResult {
+  log: string;
+  distCode: string;
+}
+
+function buildFixture(options: {
+  imports: string[];
+  neverBundle: string[];
+}): BuildResult {
+  const uniqueSuffix = `${Date.now()}-${createdDirs.length}`;
+  const root = path.join(REPO_ROOT, `.tmp-plugboy-e2e-${uniqueSuffix}`);
+  const dir = path.join(root, 'pkg');
+  createdDirs.push(root);
+
+  fs.mkdirSync(path.join(dir, 'src'), { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, 'package.json'),
+    JSON.stringify({
+      name: '@plugboy-e2e/self-ref',
+      version: '0.0.0',
+      type: 'module',
+      exports: {
+        '.': { types: './dist/pkg.d.mts', import: './dist/pkg.mjs' },
+        './*': './dist/*',
+      },
+    }),
+  );
+  // Plain object (not `defineWorkspaceConfig`) to avoid importing the package
+  // under test; `loadWorkspaceConfig` resolves the raw config itself.
+  fs.writeFileSync(
+    path.join(dir, 'plugboy.workspace.ts'),
+    `export default ${JSON.stringify({
+      ignoreProjectConfig: true,
+      entries: { '.': './src/index.ts' },
+      deps: { neverBundle: options.neverBundle },
+    })};\n`,
+  );
+  const body = options.imports
+    .map((spec, i) => `import _${i} from '${spec}';`)
+    .join('\n');
+  fs.writeFileSync(
+    path.join(dir, 'src/index.ts'),
+    `${body}\nexport const refs = [${options.imports
+      .map((_, i) => `_${i}`)
+      .join(', ')}];\n`,
+  );
+
+  const result = spawnSync(TSX_BIN, [DRIVER, dir], {
+    cwd: dir,
+    encoding: 'utf8',
+  });
+  const log = `${result.stdout ?? ''}${result.stderr ?? ''}`.replace(
+    ANSI_RE,
+    '',
+  );
+  const distPath = path.join(dir, 'dist/pkg.mjs');
+  const distCode = fs.existsSync(distPath)
+    ? fs.readFileSync(distPath, 'utf8')
+    : '';
+  return { log, distCode };
+}
+
+describe('external-imports build integration', () => {
+  test('self-reference and neverBundle subpath imports build without UNRESOLVED_IMPORT', () => {
+    const { log, distCode } = buildFixture({
+      neverBundle: ['@plugboy-e2e/self-ref', 'declared-external'],
+      imports: [
+        // self-reference subpaths (served at runtime via the exports map)
+        '@plugboy-e2e/self-ref/assets/logo.svg',
+        '@plugboy-e2e/self-ref/assets/icon.svg',
+        // a declared neverBundle package subpath
+        'declared-external/deep/thing.js',
+      ],
+    });
+
+    expect(log).not.toContain('UNRESOLVED_IMPORT');
+
+    // dist keeps every import external (statements survive verbatim).
+    expect(distCode).toContain('@plugboy-e2e/self-ref/assets/logo.svg');
+    expect(distCode).toContain('@plugboy-e2e/self-ref/assets/icon.svg');
+    expect(distCode).toContain('declared-external/deep/thing.js');
+  }, 60_000);
+
+  test('a genuinely unresolved specifier (typo) still warns', () => {
+    const { log } = buildFixture({
+      neverBundle: ['@plugboy-e2e/self-ref'],
+      imports: [
+        '@plugboy-e2e/self-ref/assets/logo.svg', // suppressed
+        '@plugboy-e2e/typo-not-declared/whoops.svg', // must still warn
+      ],
+    });
+
+    expect(log).toContain('UNRESOLVED_IMPORT');
+    expect(log).toContain('@plugboy-e2e/typo-not-declared/whoops.svg');
+    // The self-reference must not be the thing being warned about.
+    expect(log).not.toContain('self-ref/assets/logo.svg');
+  }, 60_000);
+});

--- a/packages/plugboy/__tests__/external-imports.spec.ts
+++ b/packages/plugboy/__tests__/external-imports.spec.ts
@@ -1,0 +1,95 @@
+import { describe, test, expect } from 'vitest';
+import { createExternalImportsPlugin } from '../src/workspace/plugins/external-imports';
+import { collectExternalStringPrefixes } from '../src/utils';
+import type { PlugboyWorkspace } from '../src/workspace/workspace';
+
+/**
+ * Build a plugin against a stub workspace exposing only the fields the plugin
+ * reads (`json.name`, `neverBundlePrefixes`).
+ */
+function pluginFor(name: string, neverBundlePrefixes: string[] = []) {
+  const workspace = {
+    json: { name },
+    neverBundlePrefixes,
+  } as unknown as PlugboyWorkspace;
+  const plugin = createExternalImportsPlugin(workspace);
+  const resolveId = plugin.resolveId as (
+    id: string,
+    importer?: string,
+  ) => { id: string; external: true } | null;
+  return (id: string) => resolveId(id);
+}
+
+describe('createExternalImportsPlugin', () => {
+  const resolve = pluginFor('@scope/pkg', ['@scope/other', 'plain-pkg']);
+
+  test('externalizes a self-reference by exact package name', () => {
+    expect(resolve('@scope/pkg')).toEqual({
+      id: '@scope/pkg',
+      external: true,
+    });
+  });
+
+  test('externalizes self-reference subpath imports', () => {
+    expect(resolve('@scope/pkg/assets/logo.svg')).toEqual({
+      id: '@scope/pkg/assets/logo.svg',
+      external: true,
+    });
+  });
+
+  test('externalizes declared neverBundle packages and their subpaths', () => {
+    expect(resolve('@scope/other')).toEqual({
+      id: '@scope/other',
+      external: true,
+    });
+    expect(resolve('@scope/other/deep/thing.js')).toEqual({
+      id: '@scope/other/deep/thing.js',
+      external: true,
+    });
+    expect(resolve('plain-pkg/sub')).toEqual({
+      id: 'plain-pkg/sub',
+      external: true,
+    });
+  });
+
+  test('does NOT suppress unrelated (typo) specifiers — they still warn', () => {
+    expect(resolve('@scope/typo/whoops.svg')).toBeNull();
+    expect(resolve('totally-unknown')).toBeNull();
+  });
+
+  test('respects the package-name boundary (no prefix bleed)', () => {
+    // `@scope/pkg-extra` must not be treated as a subpath of `@scope/pkg`.
+    expect(resolve('@scope/pkg-extra')).toBeNull();
+    expect(resolve('@scope/otherwise')).toBeNull();
+  });
+
+  test('ignores relative, absolute and protocol specifiers', () => {
+    expect(resolve('./local')).toBeNull();
+    expect(resolve('../up')).toBeNull();
+    expect(resolve('/abs/path')).toBeNull();
+    expect(resolve('node:fs')).toBeNull();
+    expect(resolve('data:text/plain,x')).toBeNull();
+  });
+});
+
+describe('collectExternalStringPrefixes', () => {
+  test('returns an empty array for empty input', () => {
+    expect(collectExternalStringPrefixes(undefined)).toEqual([]);
+    expect(collectExternalStringPrefixes([])).toEqual([]);
+  });
+
+  test('collects string entries, flattening nested arrays', () => {
+    expect(collectExternalStringPrefixes('a')).toEqual(['a']);
+    expect(collectExternalStringPrefixes(['a', 'b'])).toEqual(['a', 'b']);
+    expect(
+      collectExternalStringPrefixes(['a', ['b', ['c']]] as any),
+    ).toEqual(['a', 'b', 'c']);
+  });
+
+  test('skips RegExp and function entries (opaque, not prefixable)', () => {
+    expect(
+      collectExternalStringPrefixes(['keep', /drop/, () => true] as any),
+    ).toEqual(['keep']);
+    expect(collectExternalStringPrefixes(() => true)).toEqual([]);
+  });
+});

--- a/packages/plugboy/__tests__/external-imports.spec.ts
+++ b/packages/plugboy/__tests__/external-imports.spec.ts
@@ -81,9 +81,11 @@ describe('collectExternalStringPrefixes', () => {
   test('collects string entries, flattening nested arrays', () => {
     expect(collectExternalStringPrefixes('a')).toEqual(['a']);
     expect(collectExternalStringPrefixes(['a', 'b'])).toEqual(['a', 'b']);
-    expect(
-      collectExternalStringPrefixes(['a', ['b', ['c']]] as any),
-    ).toEqual(['a', 'b', 'c']);
+    expect(collectExternalStringPrefixes(['a', ['b', ['c']]] as any)).toEqual([
+      'a',
+      'b',
+      'c',
+    ]);
   });
 
   test('skips RegExp and function entries (opaque, not prefixable)', () => {

--- a/packages/plugboy/__tests__/helpers/dts-sourcemap-driver.mts
+++ b/packages/plugboy/__tests__/helpers/dts-sourcemap-driver.mts
@@ -1,0 +1,41 @@
+/**
+ * Child-process driver for the dts SOURCEMAP_BROKEN integration test.
+ *
+ * Builds a fixture through tsdown directly (mirroring plugboy's `dts: true` +
+ * `sourcemap: true` config) so the suppress plugin can be toggled and a
+ * JS-sourcemap breaker injected. Run in a fresh process so rolldown's native
+ * diagnostics (written to the OS stdout/stderr descriptors) are visible to the
+ * parent. Usage: `tsx dts-sourcemap-driver.mts <dir> <outDir> <mode>`, where
+ * mode is `suppress` | `none` | `js-breaker`.
+ */
+import { build } from 'tsdown';
+import { createSuppressDtsSourcemapWarningPlugin } from '../../src/workspace/plugins/suppress-dts-sourcemap-warning';
+
+const [, , dir, outDir, mode] = process.argv;
+process.chdir(dir);
+
+// Mutates a JS chunk's text without returning a sourcemap → rolldown emits a
+// genuine SOURCEMAP_BROKEN attributed to THIS plugin (not fake-js).
+const jsBreaker = {
+  name: 'js-sourcemap-breaker',
+  renderChunk(code: string) {
+    return `${code}\n/* mutated without a map */`;
+  },
+};
+
+const plugins = [];
+if (mode === 'suppress' || mode === 'js-breaker') {
+  plugins.push(createSuppressDtsSourcemapWarningPlugin());
+}
+if (mode === 'js-breaker') {
+  plugins.push(jsBreaker);
+}
+
+await build({
+  entry: { pkg: './src/index.ts' },
+  outDir,
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  plugins,
+});

--- a/packages/plugboy/__tests__/helpers/plugboy-build-driver.mts
+++ b/packages/plugboy/__tests__/helpers/plugboy-build-driver.mts
@@ -1,0 +1,15 @@
+/**
+ * Child-process driver for the external-imports build integration test.
+ *
+ * Run via `tsx` in a fresh process whose cwd is the fixture package, so that
+ * rolldown's native diagnostics (written directly to the process's stdout/
+ * stderr file descriptors, bypassing JS `process.stdout.write`) can be captured
+ * by the parent at the OS level. Usage: `tsx plugboy-build-driver.mts <dir>`.
+ */
+import { getWorkspace } from '../../src/workspace';
+
+const dir = process.argv[2];
+if (dir) process.chdir(dir);
+
+const workspace = await getWorkspace();
+await workspace.builder.build();

--- a/packages/plugboy/__tests__/suppress-dts-sourcemap-warning.spec.ts
+++ b/packages/plugboy/__tests__/suppress-dts-sourcemap-warning.spec.ts
@@ -1,0 +1,71 @@
+import { describe, test, expect, vi } from 'vitest';
+import { createSuppressDtsSourcemapWarningPlugin } from '../src/workspace/plugins/suppress-dts-sourcemap-warning';
+
+type OnLog = (
+  this: { debug: (log: unknown) => void },
+  level: string,
+  log: Record<string, unknown>,
+) => boolean | undefined | null | void;
+
+function setup() {
+  const plugin = createSuppressDtsSourcemapWarningPlugin();
+  const debug = vi.fn();
+  const onLog = plugin.onLog as unknown as OnLog;
+  const call = (level: string, log: Record<string, unknown>) =>
+    onLog.call({ debug }, level, log);
+  return { plugin, debug, call };
+}
+
+const FAKE_JS = 'rolldown-plugin-dts:fake-js';
+
+describe('createSuppressDtsSourcemapWarningPlugin', () => {
+  test('suppresses the fake-js SOURCEMAP_BROKEN warning and traces it at debug level', () => {
+    const { call, debug } = setup();
+    const result = call('warn', {
+      code: 'SOURCEMAP_BROKEN',
+      plugin: FAKE_JS,
+      message: 'Sourcemap is likely to be incorrect',
+    });
+    expect(result).toBe(false);
+    expect(debug).toHaveBeenCalledTimes(1);
+  });
+
+  test('does NOT suppress SOURCEMAP_BROKEN from a different plugin (real JS breakage)', () => {
+    const { call, debug } = setup();
+    const result = call('warn', {
+      code: 'SOURCEMAP_BROKEN',
+      plugin: 'some-other-plugin',
+      message: 'Sourcemap is likely to be incorrect',
+    });
+    expect(result).toBeUndefined();
+    expect(debug).not.toHaveBeenCalled();
+  });
+
+  test('does NOT suppress SOURCEMAP_BROKEN without a plugin attribution', () => {
+    const { call } = setup();
+    expect(
+      call('warn', { code: 'SOURCEMAP_BROKEN', message: 'x' }),
+    ).toBeUndefined();
+  });
+
+  test('does NOT suppress other warning codes from fake-js', () => {
+    const { call } = setup();
+    expect(
+      call('warn', { code: 'CIRCULAR_DEPENDENCY', plugin: FAKE_JS }),
+    ).toBeUndefined();
+  });
+
+  test('only acts on warn level, not info/debug', () => {
+    const { call } = setup();
+    expect(
+      call('info', { code: 'SOURCEMAP_BROKEN', plugin: FAKE_JS }),
+    ).toBeUndefined();
+  });
+
+  test('is log-only: defines no output-affecting hooks (guarantees byte-identical output)', () => {
+    const { plugin } = setup();
+    // Only `name` and `onLog` — no transform/renderChunk/generateBundle/etc.,
+    // so the plugin cannot alter build output.
+    expect(Object.keys(plugin).sort()).toEqual(['name', 'onLog']);
+  });
+});

--- a/packages/plugboy/src/types/workspace.ts
+++ b/packages/plugboy/src/types/workspace.ts
@@ -235,6 +235,14 @@ export interface WorkspaceSetupContext {
    */
   projectDependencies: string[];
   /**
+   * Package-name prefixes collected from string `deps.neverBundle` entries.
+   *
+   * Used by the external-imports plugin to externalize a declared package's
+   * subpath imports (`pkg/foo.svg`) without emitting an `UNRESOLVED_IMPORT`
+   * warning. `RegExp` / function externals are opaque and are not collected.
+   */
+  neverBundlePrefixes: string[];
+  /**
    * Workspace Meta Information
    * @see {@link WorkspaceMeta}
    */

--- a/packages/plugboy/src/utils/tsdown.ts
+++ b/packages/plugboy/src/utils/tsdown.ts
@@ -89,6 +89,31 @@ function isExternal(
   return false;
 }
 
+/**
+ * Collect the plain string entries from an {@link ExternalOption}, flattening
+ * nested arrays.
+ *
+ * Only string entries can be turned into package-name prefixes for subpath
+ * matching (`RegExp` / function entries are opaque and are skipped). Used to
+ * feed the external-imports plugin so that a `deps.neverBundle` package name
+ * also externalizes its subpath imports (e.g. `pkg/foo.svg`).
+ */
+export function collectExternalStringPrefixes(
+  option: ExternalOption | undefined,
+): string[] {
+  const prefixes: string[] = [];
+  const walk = (o: ExternalOption | undefined): void => {
+    if (!o) return;
+    if (typeof o === 'string') {
+      prefixes.push(o);
+    } else if (Array.isArray(o)) {
+      o.forEach(walk);
+    }
+  };
+  walk(option);
+  return prefixes;
+}
+
 export function mergeExternals(
   base: ExternalOption | undefined,
   override: ExternalOption | undefined,

--- a/packages/plugboy/src/workspace/plugins/external-imports.ts
+++ b/packages/plugboy/src/workspace/plugins/external-imports.ts
@@ -1,0 +1,68 @@
+import { Plugin } from '../../types';
+import type { PlugboyWorkspace } from '../workspace';
+
+/**
+ * A specifier is "bare" (a package specifier) when it is not relative, absolute,
+ * a protocol-qualified id (`node:`, `data:`, `http:`, …) or a fragment. Only
+ * bare specifiers are candidates for external resolution here.
+ */
+function isBareSpecifier(id: string): boolean {
+  return !/^(?:\.{1,2}\/|\/|[a-z][a-z\d+.-]*:|#)/i.test(id);
+}
+
+/** Whether `id` equals `name` or is a subpath of it (`name/...`). */
+function matchesPackage(id: string, name: string): boolean {
+  return id === name || id.startsWith(`${name}/`);
+}
+
+/**
+ * Resolve self-references and `deps.neverBundle` package imports as explicit
+ * externals.
+ *
+ * rolldown only externalizes a specifier without warning when it matches the
+ * `external` option *before* it tries to resolve it on disk. A `deps.neverBundle`
+ * entry is a plain string, so it matches the package name exactly but not its
+ * subpaths (`pkg/foo.svg`); and a package's own name is never in its
+ * dependencies at all. Both therefore fall through to rolldown's
+ * "resolve failed → implicit external" path, which emits a noisy
+ * `UNRESOLVED_IMPORT` warning for every such import even though the resulting
+ * external output is correct.
+ *
+ * This plugin intercepts those imports in `resolveId` and marks them external
+ * up front, so the diagnostic never fires:
+ *
+ * - **Self-reference:** a package importing its own name (or a subpath of it).
+ *   The subpath is served at runtime from the consumer's `exports` map
+ *   (`"./*": "./dist/*"`); it cannot — and must not — be bundled into the build
+ *   that produces that very `dist`, so external is always the right answer.
+ * - **`deps.neverBundle`:** the declared package names and any of their
+ *   subpaths.
+ *
+ * Specifiers that match neither are returned untouched, so genuine unresolved
+ * imports (typos in a non-external package) still surface their warning.
+ */
+export function createExternalImportsPlugin(
+  workspace: PlugboyWorkspace,
+): Plugin {
+  const selfName = workspace.json.name;
+  const { neverBundlePrefixes } = workspace;
+
+  return {
+    name: 'plugboy:external-imports',
+    resolveId(id) {
+      if (!isBareSpecifier(id)) return null;
+
+      if (selfName && matchesPackage(id, selfName)) {
+        return { id, external: true };
+      }
+
+      for (const prefix of neverBundlePrefixes) {
+        if (matchesPackage(id, prefix)) {
+          return { id, external: true };
+        }
+      }
+
+      return null;
+    },
+  };
+}

--- a/packages/plugboy/src/workspace/plugins/index.ts
+++ b/packages/plugboy/src/workspace/plugins/index.ts
@@ -1,2 +1,4 @@
 export * from './raw-loader';
 export * from './preserve-css-imports';
+export * from './external-imports';
+export * from './suppress-dts-sourcemap-warning';

--- a/packages/plugboy/src/workspace/plugins/suppress-dts-sourcemap-warning.ts
+++ b/packages/plugboy/src/workspace/plugins/suppress-dts-sourcemap-warning.ts
@@ -1,0 +1,50 @@
+import { Plugin } from '../../types';
+
+/**
+ * The rolldown-plugin-dts sub-plugin that drives declaration bundling through a
+ * "fake JS" module. Its `renderChunk` returns a bare `"export { };"` string
+ * (with no sourcemap) whenever a `.d.ts` chunk reduces to an empty body — e.g.
+ * an entry composed solely of external re-exports. With sourcemaps enabled
+ * (plugboy sets `sourcemap: true` for the JS output, which the dts pipeline
+ * inherits), rolldown then emits a spurious `[SOURCEMAP_BROKEN]` warning for a
+ * declaration file that is perfectly correct.
+ */
+const DTS_FAKE_JS_PLUGIN_NAME = 'rolldown-plugin-dts:fake-js';
+
+/**
+ * Suppress the harmless `[SOURCEMAP_BROKEN]` warning that rolldown-plugin-dts's
+ * fake-js pass emits for empty declaration chunks.
+ *
+ * The filter is intentionally narrow — it only drops a `warn`-level
+ * `SOURCEMAP_BROKEN` log **attributed to `rolldown-plugin-dts:fake-js`**. Real
+ * sourcemap breakage on JS output (emitted by other plugins, or with no plugin
+ * attribution) has a different `plugin` field and passes through untouched, so
+ * genuine problems are still reported.
+ *
+ * The suppression is re-emitted at `debug` level so it can be traced by running
+ * a build with a debug log level.
+ *
+ * TODO(upstream): remove this workaround once rolldown-plugin-dts returns a
+ * valid (empty) sourcemap for empty chunks instead of a bare string. Track at
+ * https://github.com/sxzz/rolldown-plugin-dts and, once fixed, bump the tsdown
+ * (rolldown-plugin-dts) dependency range and delete this file, its re-export
+ * from `./index`, and its registration in `workspace.ts`.
+ */
+export function createSuppressDtsSourcemapWarningPlugin(): Plugin {
+  return {
+    name: 'plugboy:suppress-dts-sourcemap-warning',
+    onLog(level, log) {
+      if (
+        level === 'warn' &&
+        log.code === 'SOURCEMAP_BROKEN' &&
+        log.plugin === DTS_FAKE_JS_PLUGIN_NAME
+      ) {
+        this.debug(() => ({
+          code: 'PLUGBOY_SUPPRESSED_DTS_SOURCEMAP_BROKEN',
+          message: `Suppressed a spurious [SOURCEMAP_BROKEN] warning from ${DTS_FAKE_JS_PLUGIN_NAME} for an empty declaration chunk. Original message: ${log.message}`,
+        }));
+        return false;
+      }
+    },
+  };
+}

--- a/packages/plugboy/src/workspace/workspace.ts
+++ b/packages/plugboy/src/workspace/workspace.ts
@@ -8,6 +8,7 @@ import {
   buildHooks,
   mergeExternals,
   mergeNoExternals,
+  collectExternalStringPrefixes,
   writeFileAtomic,
 } from '../utils';
 import {
@@ -32,7 +33,12 @@ import { Builder } from './builder';
 import { getWorkspacePackageJson } from '../package';
 import { WorkspaceEnvPlugin } from '../env';
 import { OptimizeCSSPlugin } from '../postcss/plugin';
-import { rawLoaderPlugin, createPreserveCssImportsPlugin } from './plugins';
+import {
+  rawLoaderPlugin,
+  createPreserveCssImportsPlugin,
+  createExternalImportsPlugin,
+  createSuppressDtsSourcemapWarningPlugin,
+} from './plugins';
 import { type CssOptions } from '@tsdown/css';
 
 export type WorkspaceStubLink =
@@ -108,6 +114,8 @@ export class PlugboyWorkspace {
 
   readonly projectDependencies: string[];
 
+  readonly neverBundlePrefixes: string[];
+
   readonly meta: WorkspaceMeta;
 
   readonly entry: Record<string, string>;
@@ -143,6 +151,7 @@ export class PlugboyWorkspace {
       dirs,
       dependencies,
       projectDependencies,
+      neverBundlePrefixes,
       meta,
       plugins,
       hooks,
@@ -158,9 +167,17 @@ export class PlugboyWorkspace {
     this.dirs = dirs;
     this.dependencies = dependencies;
     this.projectDependencies = projectDependencies;
+    this.neverBundlePrefixes = neverBundlePrefixes;
     this.meta = meta;
     this.config = config;
     this.plugins = [
+      // Runs first so self-reference / `neverBundle` imports are marked external
+      // before any resolver (built-in or user) can attempt — and fail — to
+      // resolve them on disk.
+      createExternalImportsPlugin(this),
+      // Filters the spurious dts SOURCEMAP_BROKEN warning; harmless if the dts
+      // pipeline is absent, so it can live alongside the other plugins.
+      createSuppressDtsSourcemapWarningPlugin(),
       ...plugins,
       OptimizeCSSPlugin(this),
       WorkspaceEnvPlugin(this),
@@ -392,6 +409,13 @@ export async function getWorkspace<
 
   const meta: WorkspaceMeta = {};
 
+  // Prefixes for the external-imports plugin. Seeded from the user's initial
+  // `deps.neverBundle` and extended by any `ctx.mergeExternals` calls made
+  // during workspace setup (see below).
+  const neverBundlePrefixes = collectExternalStringPrefixes(
+    config.deps?.neverBundle,
+  );
+
   const projectPlugins = project?.plugins || [];
   const projectHooks = project?.hooks || [];
   const plugins: Plugin[] = [...projectPlugins, ...config.plugins];
@@ -425,6 +449,7 @@ export async function getWorkspace<
     dirs,
     dependencies: _dependencies,
     projectDependencies,
+    neverBundlePrefixes,
     meta,
     plugins,
     hooks,
@@ -438,6 +463,7 @@ export async function getWorkspace<
         config.deps.neverBundle,
         override,
       );
+      neverBundlePrefixes.push(...collectExternalStringPrefixes(override));
     },
     mergeNoExternals: (override) => {
       config.deps ??= {};

--- a/packages/vue-page/src/composables/page-control.ts
+++ b/packages/vue-page/src/composables/page-control.ts
@@ -509,12 +509,12 @@ export class VuePageControl extends EV<VuePageControlEventMap> {
     return data;
   }
 
-  useState<T extends object>(key: StateInjectionKey<T>): T | undefined; // eslint-disable-line prettier/prettier
+  useState<T extends object>(key: StateInjectionKey<T>): T | undefined;
 
   useState<T extends object>(
     key: StateInjectionKey<T>,
     defaultValue: T | (() => T),
-  ): T; // eslint-disable-line prettier/prettier
+  ): T;
 
   useState<T extends object>(
     key: StateInjectionKey<T>,
@@ -542,13 +542,13 @@ export class VuePageControl extends EV<VuePageControlEventMap> {
     key: InjectionKey<T> | string,
     defaultValue: T,
     treatDefaultAsFactory?: false,
-  ): T; // eslint-disable-line prettier/prettier
+  ): T;
 
   inject<T>(
     key: InjectionKey<T> | string,
     defaultValue: T | (() => T),
     treatDefaultAsFactory: true,
-  ): T; // eslint-disable-line prettier/prettier
+  ): T;
 
   inject<T>(
     key: InjectionKey<T> | string,

--- a/packages/vue-page/src/composables/state.ts
+++ b/packages/vue-page/src/composables/state.ts
@@ -4,11 +4,11 @@ export type StateInjectionKey<T extends object> = string;
 
 export function useState<T extends object>(
   key: StateInjectionKey<T>,
-): T | undefined; // eslint-disable-line prettier/prettier
+): T | undefined;
 export function useState<T extends object>(
   key: StateInjectionKey<T>,
   defaultValue: T | (() => T),
-): T; // eslint-disable-line prettier/prettier
+): T;
 export function useState<T extends object>(
   key: StateInjectionKey<T>,
   defaultValue?: T | (() => T),

--- a/packages/vue-utils/src/utils/router.ts
+++ b/packages/vue-utils/src/utils/router.ts
@@ -93,46 +93,46 @@ export type RouteQueryType =
 export function getRouteQuery(
   bucket: LocationQuery,
   key: string,
-): string | undefined; // eslint-disable-line prettier/prettier
+): string | undefined;
 export function getRouteQuery(
   bucket: LocationQuery,
   key: string,
   type: undefined,
   defaultValue: string,
-): string; // eslint-disable-line prettier/prettier
+): string;
 export function getRouteQuery(
   bucket: LocationQuery,
   key: string,
   type: StringConstructor,
-): string | undefined; // eslint-disable-line prettier/prettier
+): string | undefined;
 export function getRouteQuery(
   bucket: LocationQuery,
   key: string,
   type: StringConstructor,
   defaultValue: string,
-): string; // eslint-disable-line prettier/prettier
+): string;
 export function getRouteQuery(
   bucket: LocationQuery,
   key: string,
   type: NumberConstructor,
-): number | undefined; // eslint-disable-line prettier/prettier
+): number | undefined;
 export function getRouteQuery(
   bucket: LocationQuery,
   key: string,
   type: NumberConstructor,
   defaultValue: number,
-): number; // eslint-disable-line prettier/prettier
+): number;
 export function getRouteQuery(
   bucket: LocationQuery,
   key: string,
   type: BooleanConstructor,
-): boolean; // eslint-disable-line prettier/prettier
+): boolean;
 export function getRouteQuery(
   bucket: LocationQuery,
   key: string,
   type: BooleanConstructor,
   defaultValue: boolean,
-): boolean; // eslint-disable-line prettier/prettier
+): boolean;
 export function getRouteQuery(
   bucket: LocationQuery,
   key: string,


### PR DESCRIPTION
## Summary

Two classes of harmless-but-noisy rolldown warnings were flooding plugboy build logs, making genuine diagnostics (typos, real sourcemap breakage) easy to miss. This PR eliminates both — narrowly scoped so real problems still surface.

### 1. `UNRESOLVED_IMPORT` for self-reference / `deps.neverBundle` imports
A new `plugboy:external-imports` plugin resolves the following as explicit externals **before** rolldown tries (and fails) to resolve them on disk:

- **Self-references** — a package importing its own name or a subpath (e.g. `import logo from 'my-pkg/assets/logo.svg'`), served at runtime via the package's `exports` map (`"./*": "./dist/*"`). No need to list your own package in `neverBundle`.
- **`deps.neverBundle` subpaths** — matching is now by package name **and** its subpaths (`'foo'` externalizes `foo` and `foo/bar`).

Genuinely unresolved specifiers (typos) still warn. Existing packages are unaffected (no package self-imports or declares `deps.neverBundle`), so build output is unchanged.

### 2. `SOURCEMAP_BROKEN` for empty declaration chunks
`rolldown-plugin-dts`'s fake-js pass returns a source-map-less `"export { };"` string for empty `.d.ts` chunks (e.g. an entry composed solely of external re-exports), which makes rolldown emit a spurious `SOURCEMAP_BROKEN` warning. A new `plugboy:suppress-dts-sourcemap-warning` plugin filters it via an `onLog` hook — **only** when attributed to `rolldown-plugin-dts:fake-js`. Genuine JS-chunk sourcemap breakage (a different `plugin` attribution) still warns. The suppression is traceable at debug log level, and is documented as an upstream workaround with a removal TODO.

## Verification
- Build output is **byte-identical** with/without the fixes (declaration + JS).
- Real-build integration tests confirm: warnings gone for the affected shapes, and both a typo (`UNRESOLVED_IMPORT`) and a genuine JS sourcemap break (`SOURCEMAP_BROKEN`) still warn.
- `pnpm --filter @fastkit/plugboy test` → 22 passing; `typecheck` clean.

## Tests added
- `external-imports.spec.ts` / `suppress-dts-sourcemap-warning.spec.ts` — unit tests for the plugin logic.
- `external-imports.build.spec.ts` / `dts-sourcemap-warning.build.spec.ts` — real-build integration tests (fixtures generated at test time under the repo root, removed afterwards, so they never enter the pnpm/Turbo/tsc graph).

## Notes
- README (EN + JA) documents the dependency-externalization behavior.
- The `SOURCEMAP_BROKEN` filter is a workaround for an upstream `rolldown-plugin-dts` bug (mapless `renderChunk` return for empty chunks); flagged for removal once fixed upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)