### PR TITLE
fix(docs): declare @fastkit/ts-tiny-meta devDependency (fixes Release docs build)

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -46,6 +46,7 @@
   "devDependencies": {
     "@fastkit/color-scheme-gen": "workspace:^",
     "@fastkit/node-util": "workspace:^",
+    "@fastkit/ts-tiny-meta": "workspace:^",
     "@mdi/svg": "^7.4.47",
     "@types/prismjs": "^1.26.6",
     "fs-extra": "^11.3.5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -203,6 +203,9 @@ importers:
       '@fastkit/node-util':
         specifier: workspace:^
         version: link:../../packages/node-util
+      '@fastkit/ts-tiny-meta':
+        specifier: workspace:^
+        version: link:../../packages/ts-tiny-meta
       '@mdi/svg':
         specifier: ^7.4.47
         version: 7.4.47
@@ -721,22 +724,22 @@ importers:
         version: 4.0.9(postcss@8.5.15)
       stylelint:
         specifier: ^17.0.0
-        version: 17.13.0(typescript@6.0.3)
+        version: 17.13.0(supports-color@5.5.0)(typescript@6.0.3)
       stylelint-config-css-modules:
         specifier: ^4.6.0
-        version: 4.6.0(stylelint@17.13.0(typescript@6.0.3))
+        version: 4.6.0(stylelint@17.13.0(supports-color@5.5.0)(typescript@6.0.3))
       stylelint-config-recess-order:
         specifier: ^7.7.0
-        version: 7.7.0(stylelint-order@8.1.1(stylelint@17.13.0(typescript@6.0.3)))(stylelint@17.13.0(typescript@6.0.3))
+        version: 7.7.0(stylelint-order@8.1.1(stylelint@17.13.0(supports-color@5.5.0)(typescript@6.0.3)))(stylelint@17.13.0(supports-color@5.5.0)(typescript@6.0.3))
       stylelint-config-standard:
         specifier: ^40.0.0
-        version: 40.0.0(stylelint@17.13.0(typescript@6.0.3))
+        version: 40.0.0(stylelint@17.13.0(supports-color@5.5.0)(typescript@6.0.3))
       stylelint-config-standard-scss:
         specifier: ^17.0.0
-        version: 17.0.0(postcss@8.5.15)(stylelint@17.13.0(typescript@6.0.3))
+        version: 17.0.0(postcss@8.5.15)(stylelint@17.13.0(supports-color@5.5.0)(typescript@6.0.3))
       stylelint-order:
         specifier: ^8.0.0
-        version: 8.1.1(stylelint@17.13.0(typescript@6.0.3))
+        version: 8.1.1(stylelint@17.13.0(supports-color@5.5.0)(typescript@6.0.3))
 
   packages/stylelint-config-vue:
     dependencies:
@@ -745,7 +748,7 @@ importers:
         version: link:../stylelint-config
       stylelint:
         specifier: ^17.0.0
-        version: 17.13.0(typescript@6.0.3)
+        version: 17.13.0(supports-color@5.5.0)(typescript@6.0.3)
       stylelint-config-recommended-vue:
         specifier: ^1.6.1
         version: 1.6.1(postcss-html@1.8.1)(stylelint@17.13.0(typescript@6.0.3))
@@ -14762,28 +14765,28 @@ snapshots:
       postcss: 8.5.15
       postcss-selector-parser: 7.1.4
 
-  stylelint-config-css-modules@4.6.0(stylelint@17.13.0(typescript@6.0.3)):
+  stylelint-config-css-modules@4.6.0(stylelint@17.13.0(supports-color@5.5.0)(typescript@6.0.3)):
     dependencies:
-      stylelint: 17.13.0(typescript@6.0.3)
+      stylelint: 17.13.0(supports-color@5.5.0)(typescript@6.0.3)
     optionalDependencies:
-      stylelint-scss: 7.2.0(stylelint@17.13.0(typescript@6.0.3))
+      stylelint-scss: 7.2.0(stylelint@17.13.0(supports-color@5.5.0)(typescript@6.0.3))
 
   stylelint-config-html@1.1.0(postcss-html@1.8.1)(stylelint@17.13.0(typescript@6.0.3)):
     dependencies:
       postcss-html: 1.8.1
-      stylelint: 17.13.0(typescript@6.0.3)
+      stylelint: 17.13.0(supports-color@5.5.0)(typescript@6.0.3)
 
-  stylelint-config-recess-order@7.7.0(stylelint-order@8.1.1(stylelint@17.13.0(typescript@6.0.3)))(stylelint@17.13.0(typescript@6.0.3)):
+  stylelint-config-recess-order@7.7.0(stylelint-order@8.1.1(stylelint@17.13.0(supports-color@5.5.0)(typescript@6.0.3)))(stylelint@17.13.0(supports-color@5.5.0)(typescript@6.0.3)):
     dependencies:
-      stylelint: 17.13.0(typescript@6.0.3)
-      stylelint-order: 8.1.1(stylelint@17.13.0(typescript@6.0.3))
+      stylelint: 17.13.0(supports-color@5.5.0)(typescript@6.0.3)
+      stylelint-order: 8.1.1(stylelint@17.13.0(supports-color@5.5.0)(typescript@6.0.3))
 
-  stylelint-config-recommended-scss@17.0.1(postcss@8.5.15)(stylelint@17.13.0(typescript@6.0.3)):
+  stylelint-config-recommended-scss@17.0.1(postcss@8.5.15)(stylelint@17.13.0(supports-color@5.5.0)(typescript@6.0.3)):
     dependencies:
       postcss-scss: 4.0.9(postcss@8.5.15)
-      stylelint: 17.13.0(typescript@6.0.3)
+      stylelint: 17.13.0(supports-color@5.5.0)(typescript@6.0.3)
       stylelint-config-recommended: 18.0.0(stylelint@17.13.0(typescript@6.0.3))
-      stylelint-scss: 7.2.0(stylelint@17.13.0(typescript@6.0.3))
+      stylelint-scss: 7.2.0(stylelint@17.13.0(supports-color@5.5.0)(typescript@6.0.3))
     optionalDependencies:
       postcss: 8.5.15
 
@@ -14791,32 +14794,32 @@ snapshots:
     dependencies:
       postcss-html: 1.8.1
       semver: 7.6.2
-      stylelint: 17.13.0(typescript@6.0.3)
+      stylelint: 17.13.0(supports-color@5.5.0)(typescript@6.0.3)
       stylelint-config-html: 1.1.0(postcss-html@1.8.1)(stylelint@17.13.0(typescript@6.0.3))
       stylelint-config-recommended: 18.0.0(stylelint@17.13.0(typescript@6.0.3))
 
   stylelint-config-recommended@18.0.0(stylelint@17.13.0(typescript@6.0.3)):
     dependencies:
-      stylelint: 17.13.0(typescript@6.0.3)
+      stylelint: 17.13.0(supports-color@5.5.0)(typescript@6.0.3)
 
-  stylelint-config-standard-scss@17.0.0(postcss@8.5.15)(stylelint@17.13.0(typescript@6.0.3)):
+  stylelint-config-standard-scss@17.0.0(postcss@8.5.15)(stylelint@17.13.0(supports-color@5.5.0)(typescript@6.0.3)):
     dependencies:
-      stylelint: 17.13.0(typescript@6.0.3)
-      stylelint-config-recommended-scss: 17.0.1(postcss@8.5.15)(stylelint@17.13.0(typescript@6.0.3))
-      stylelint-config-standard: 40.0.0(stylelint@17.13.0(typescript@6.0.3))
+      stylelint: 17.13.0(supports-color@5.5.0)(typescript@6.0.3)
+      stylelint-config-recommended-scss: 17.0.1(postcss@8.5.15)(stylelint@17.13.0(supports-color@5.5.0)(typescript@6.0.3))
+      stylelint-config-standard: 40.0.0(stylelint@17.13.0(supports-color@5.5.0)(typescript@6.0.3))
     optionalDependencies:
       postcss: 8.5.15
 
-  stylelint-config-standard@40.0.0(stylelint@17.13.0(typescript@6.0.3)):
+  stylelint-config-standard@40.0.0(stylelint@17.13.0(supports-color@5.5.0)(typescript@6.0.3)):
     dependencies:
-      stylelint: 17.13.0(typescript@6.0.3)
+      stylelint: 17.13.0(supports-color@5.5.0)(typescript@6.0.3)
       stylelint-config-recommended: 18.0.0(stylelint@17.13.0(typescript@6.0.3))
 
-  stylelint-order@8.1.1(stylelint@17.13.0(typescript@6.0.3)):
+  stylelint-order@8.1.1(stylelint@17.13.0(supports-color@5.5.0)(typescript@6.0.3)):
     dependencies:
       postcss: 8.5.15
       postcss-sorting: 10.0.0(postcss@8.5.15)
-      stylelint: 17.13.0(typescript@6.0.3)
+      stylelint: 17.13.0(supports-color@5.5.0)(typescript@6.0.3)
 
   stylelint-prettier@5.0.3(prettier@3.9.1)(stylelint@17.14.0(supports-color@5.5.0)(typescript@6.0.3)):
     dependencies:
@@ -14824,7 +14827,7 @@ snapshots:
       prettier-linter-helpers: 1.0.0
       stylelint: 17.14.0(supports-color@5.5.0)(typescript@6.0.3)
 
-  stylelint-scss@7.2.0(stylelint@17.13.0(typescript@6.0.3)):
+  stylelint-scss@7.2.0(stylelint@17.13.0(supports-color@5.5.0)(typescript@6.0.3)):
     dependencies:
       '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
@@ -14837,9 +14840,9 @@ snapshots:
       postcss-resolve-nested-selector: 0.1.6
       postcss-selector-parser: 7.1.4
       postcss-value-parser: 4.2.0
-      stylelint: 17.13.0(typescript@6.0.3)
+      stylelint: 17.13.0(supports-color@5.5.0)(typescript@6.0.3)
 
-  stylelint@17.13.0(typescript@6.0.3):
+  stylelint@17.13.0(supports-color@5.5.0)(typescript@6.0.3):
     dependencies:
       '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)


### PR DESCRIPTION
## Problem

The post-merge **Release → Build docs** step fails:

```
docs:build: vite.config.ts (6:31) [UNRESOLVED_IMPORT] Could not resolve '@fastkit/ts-tiny-meta/vite'
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../node_modules/@fastkit/ts-tiny-meta/dist/vite.mjs'
Failed: docs#build
```

`apps/docs/vite.config.ts` imports `@fastkit/ts-tiny-meta/vite`, but `apps/docs` never declared `@fastkit/ts-tiny-meta`. `build:docs` runs `turbo run build --filter=docs`, which builds only packages in docs's own dependency graph — so `@fastkit/ts-tiny-meta` was never built and `dist/vite.mjs` didn't exist when `vot build` loaded the Vite config.

It used to resolve only incidentally (`@fastkit/vue-tiny-meta` — which depends on `@fastkit/ts-tiny-meta` — was removed as unused in #167, taking that transitive build edge with it; and locally, leftover `dist` masked it). The docs app is `private`, so the `audit:deps` dist check (which skips private packages) didn't catch this phantom.

## Fix

Declare `@fastkit/ts-tiny-meta` as a `devDependency` of `apps/docs`. This puts it into docs's turbo graph so `--filter=docs` builds it before `docs#build`, and guarantees resolution.

## Verification

- **Reproduced the CI failure locally**: remove the declaration + `rm -rf packages/ts-tiny-meta/dist` → `pnpm build:docs` fails with the identical error (exit 1).
- **Confirmed the fix**: with the declaration, `pnpm build:docs` is green (51/51, `@fastkit/ts-tiny-meta#build` now runs as part of the docs graph, 222 pages generated).

No changeset — `docs` is `private`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
