### PR TITLE
feat(plugboy): add Vite-compatible ambient module types to env.d.ts

### DIFF
--- a/.changeset/plugboy-vite-compatible-module-types.md
+++ b/.changeset/plugboy-vite-compatible-module-types.md
@@ -1,0 +1,5 @@
+---
+"@fastkit/plugboy": minor
+---
+
+Add Vite-compatible ambient module types to the `@fastkit/plugboy/env` subpath. Referencing it (already required for the `__PLUGBOY_DEV__` / `__PLUGBOY_STUB__` constants) now also types the non-JS imports plugboy can bundle, mirroring a subset of Vite's `vite/client` types so source written for Vite/tsdown type-checks the same way: static assets (images, media, fonts, `.webmanifest`, `.pdf`, `.txt`, …) as a `string` default export, CSS side-effect imports and CSS Modules, and `?raw` as a `string`. Vite-only features without a plugboy loader (`?url` / `?inline`, `?worker` / `?sharedworker`, `*.wasm?init`, `vite/modulepreload-polyfill`, `vite:preloadError`) are intentionally omitted so the types never imply unsupported behavior.

--- a/packages/plugboy/README-ja.md
+++ b/packages/plugboy/README-ja.md
@@ -15,7 +15,7 @@
 - **CSS統合**: Sass、Vanilla Extract、CSS最適化サポート
 - **開発効率**: stub機能による高速開発サイクル
 - **自動化**: package.json、exports自動生成
-- **環境定数**: 開発時のみのコードを切り分ける `__PLUGBOY_DEV__` / `__PLUGBOY_STUB__`（[ドキュメント](./docs/env-constants-ja.md)）
+- **環境定数とモジュール型**: 開発時ガードの `__PLUGBOY_DEV__` / `__PLUGBOY_STUB__` に加え、アセット・CSS・`?raw` インポート向けの Vite 互換アンビエント型（[ドキュメント](./docs/env-constants-ja.md)）
 
 ## インストール
 

--- a/packages/plugboy/README.md
+++ b/packages/plugboy/README.md
@@ -16,7 +16,7 @@ A monorepo-compatible module bundler and project management tool. Provides a hig
 - **CSS Integration**: Sass, Vanilla Extract, and CSS optimization support
 - **Development Efficiency**: Fast development cycle with stub functionality
 - **Automation**: Automatic generation of package.json and exports
-- **Env Constants**: `__PLUGBOY_DEV__` / `__PLUGBOY_STUB__` for guarding dev-only code ([docs](./docs/env-constants.md))
+- **Env & Module Types**: `__PLUGBOY_DEV__` / `__PLUGBOY_STUB__` dev guards, plus Vite-compatible ambient types for asset, CSS, and `?raw` imports ([docs](./docs/env-constants.md))
 
 ## Installation
 

--- a/packages/plugboy/docs/env-constants-ja.md
+++ b/packages/plugboy/docs/env-constants-ja.md
@@ -1,4 +1,4 @@
-# 環境定数（Env constants）
+# 環境定数とモジュール型（Env constants & module types）
 
 🌐 [English](./env-constants.md) | 日本語
 
@@ -33,7 +33,7 @@ if (__PLUGBOY_STUB__) {
 ## TypeScript
 
 グローバル型は `@fastkit/plugboy/env` サブパスから提供されます。一度参照すれば
-（例: パッケージ内の任意の `*.d.ts`）定数が型付けされます。
+（例: パッケージ内の任意の `*.d.ts`）定数と、後述の[モジュール型](#モジュール型assetscssraw)が型付けされます。
 
 ```ts
 /// <reference types="@fastkit/plugboy/env" />
@@ -48,3 +48,28 @@ if (__PLUGBOY_STUB__) {
   }
 }
 ```
+
+## モジュール型（assets・CSS・?raw）
+
+同じ `@fastkit/plugboy/env` の参照は、plugboy がバンドルできる非JSインポート向けの
+アンビエントモジュール型も宣言します。これは Vite の `vite/client` 型のサブセットに
+準拠しており、Vite（や tsdown）向けに書かれたソースが同じように型チェックされます。
+
+- **静的アセット**（画像・メディア・フォント・`.webmanifest`・`.pdf`・`.txt` など）
+  — `string` を default export します。
+- **CSS** — side-effect インポート（`*.css`・`*.scss` など）と CSS Modules
+  （`*.module.css` → クラス名マップ）。
+- **`?raw`** — ファイルの内容を `string` として取得します。
+
+```ts
+import iconUrl from './icon.svg'; // string
+import styles from './button.module.css'; // { readonly [key: string]: string }
+import shader from './shader.glsl?raw'; // string
+import './global.css'; // 副作用のみ
+```
+
+型付けされるのは plugboy が実際に処理するインポートだけです。plugboy にローダーの無い
+Vite 固有機能は、未対応の挙動を型が示唆しないよう意図的に除外しています:
+`?url` / `?inline`、`?worker` / `?sharedworker`、`*.wasm?init`、
+`vite/modulepreload-polyfill`、`vite:preloadError` イベント。開発時ガードには
+`import.meta.env` ではなく `__PLUGBOY_DEV__` を使ってください。

--- a/packages/plugboy/docs/env-constants.md
+++ b/packages/plugboy/docs/env-constants.md
@@ -1,4 +1,4 @@
-# Env constants
+# Env constants & module types
 
 🌐 English | [日本語](./env-constants-ja.md)
 
@@ -42,7 +42,8 @@ if (__PLUGBOY_STUB__) {
 ## TypeScript
 
 The global types ship from the `@fastkit/plugboy/env` subpath. Reference it once
-(e.g. in a `*.d.ts` in your package) so the constants are typed:
+(e.g. in a `*.d.ts` in your package) so the constants — and the [module
+types](#module-types-assets-css-raw) below — are typed:
 
 ```ts
 /// <reference types="@fastkit/plugboy/env" />
@@ -57,3 +58,28 @@ Or add it to `tsconfig.json`:
   }
 }
 ```
+
+## Module types (assets, CSS, `?raw`)
+
+The same `@fastkit/plugboy/env` reference also declares ambient module types for
+the non-JS imports plugboy can bundle, mirroring a subset of Vite's `vite/client`
+types. Source written for Vite (or tsdown) type-checks the same way here:
+
+- **Static assets** (images, media, fonts, `.webmanifest`, `.pdf`, `.txt`, …) —
+  default-export a `string`.
+- **CSS** — side-effect imports (`*.css`, `*.scss`, …) and CSS Modules
+  (`*.module.css` → a class-name map).
+- **`?raw`** — the file contents as a `string`.
+
+```ts
+import iconUrl from './icon.svg'; // string
+import styles from './button.module.css'; // { readonly [key: string]: string }
+import shader from './shader.glsl?raw'; // string
+import './global.css'; // side-effect only
+```
+
+Only imports plugboy actually handles are typed. Vite-only features without a
+plugboy loader are intentionally omitted so the types never imply unsupported
+behavior: `?url` / `?inline`, `?worker` / `?sharedworker`, `*.wasm?init`,
+`vite/modulepreload-polyfill`, and the `vite:preloadError` event. For dev
+guards, use `__PLUGBOY_DEV__` rather than `import.meta.env`.

--- a/packages/plugboy/env.d.ts
+++ b/packages/plugboy/env.d.ts
@@ -19,4 +19,217 @@ declare global {
   const __PLUGBOY_STUB__: boolean;
 }
 
+// The declarations below mirror the subset of Vite's `vite/client` module
+// declarations that Plugboy is compatible with, so that source that already
+// targets Vite type-checks the same way under Plugboy. Only imports Plugboy
+// actually handles are declared here:
+// - CSS is processed via `@tsdown/css` (side-effect imports and CSS Modules).
+// - Static assets resolve to a `string` default export (rolldown default).
+// - `?raw` resolves to the file contents as a `string` (Plugboy's raw loader).
+//
+// Vite-only features without a Plugboy loader are intentionally omitted so the
+// types never imply support that does not exist: `?url` / `?inline`,
+// `?worker` / `?sharedworker`, `*.wasm?init`, `vite/modulepreload-polyfill`,
+// and the `vite:preloadError` event. Use `__PLUGBOY_DEV__` instead of
+// `import.meta.env`, which Plugboy does not type on the source side.
+
+// CSS modules
+type CSSModuleClasses = { readonly [key: string]: string };
+
+declare module '*.module.css' {
+  const classes: CSSModuleClasses;
+  export default classes;
+}
+declare module '*.module.scss' {
+  const classes: CSSModuleClasses;
+  export default classes;
+}
+declare module '*.module.sass' {
+  const classes: CSSModuleClasses;
+  export default classes;
+}
+declare module '*.module.less' {
+  const classes: CSSModuleClasses;
+  export default classes;
+}
+declare module '*.module.styl' {
+  const classes: CSSModuleClasses;
+  export default classes;
+}
+declare module '*.module.stylus' {
+  const classes: CSSModuleClasses;
+  export default classes;
+}
+declare module '*.module.pcss' {
+  const classes: CSSModuleClasses;
+  export default classes;
+}
+declare module '*.module.sss' {
+  const classes: CSSModuleClasses;
+  export default classes;
+}
+
+// CSS
+declare module '*.css' {}
+declare module '*.scss' {}
+declare module '*.sass' {}
+declare module '*.less' {}
+declare module '*.styl' {}
+declare module '*.stylus' {}
+declare module '*.pcss' {}
+declare module '*.sss' {}
+
+// Built-in asset types
+// see `src/node/constants.ts`
+
+// images
+declare module '*.apng' {
+  const src: string;
+  export default src;
+}
+declare module '*.bmp' {
+  const src: string;
+  export default src;
+}
+declare module '*.png' {
+  const src: string;
+  export default src;
+}
+declare module '*.jpg' {
+  const src: string;
+  export default src;
+}
+declare module '*.jpeg' {
+  const src: string;
+  export default src;
+}
+declare module '*.jfif' {
+  const src: string;
+  export default src;
+}
+declare module '*.pjpeg' {
+  const src: string;
+  export default src;
+}
+declare module '*.pjp' {
+  const src: string;
+  export default src;
+}
+declare module '*.gif' {
+  const src: string;
+  export default src;
+}
+declare module '*.svg' {
+  const src: string;
+  export default src;
+}
+declare module '*.ico' {
+  const src: string;
+  export default src;
+}
+declare module '*.webp' {
+  const src: string;
+  export default src;
+}
+declare module '*.avif' {
+  const src: string;
+  export default src;
+}
+declare module '*.cur' {
+  const src: string;
+  export default src;
+}
+declare module '*.jxl' {
+  const src: string;
+  export default src;
+}
+
+// media
+declare module '*.mp4' {
+  const src: string;
+  export default src;
+}
+declare module '*.webm' {
+  const src: string;
+  export default src;
+}
+declare module '*.ogg' {
+  const src: string;
+  export default src;
+}
+declare module '*.mp3' {
+  const src: string;
+  export default src;
+}
+declare module '*.wav' {
+  const src: string;
+  export default src;
+}
+declare module '*.flac' {
+  const src: string;
+  export default src;
+}
+declare module '*.aac' {
+  const src: string;
+  export default src;
+}
+declare module '*.opus' {
+  const src: string;
+  export default src;
+}
+declare module '*.mov' {
+  const src: string;
+  export default src;
+}
+declare module '*.m4a' {
+  const src: string;
+  export default src;
+}
+declare module '*.vtt' {
+  const src: string;
+  export default src;
+}
+
+// fonts
+declare module '*.woff' {
+  const src: string;
+  export default src;
+}
+declare module '*.woff2' {
+  const src: string;
+  export default src;
+}
+declare module '*.eot' {
+  const src: string;
+  export default src;
+}
+declare module '*.ttf' {
+  const src: string;
+  export default src;
+}
+declare module '*.otf' {
+  const src: string;
+  export default src;
+}
+
+// other
+declare module '*.webmanifest' {
+  const src: string;
+  export default src;
+}
+declare module '*.pdf' {
+  const src: string;
+  export default src;
+}
+declare module '*.txt' {
+  const src: string;
+  export default src;
+}
+
+// `?raw` — file contents as a string (Plugboy raw loader)
+declare module '*?raw' {
+  const src: string;
+  export default src;
+}
+
 export {};


### PR DESCRIPTION
## Overview

Add Vite-compatible ambient module types to the `@fastkit/plugboy/env` subpath (`env.d.ts`). The same reference already required for the `__PLUGBOY_DEV__` / `__PLUGBOY_STUB__` constants (`"types": ["@fastkit/plugboy/env"]`) now also types the non-JS imports plugboy can bundle, mirroring a subset of Vite's `vite/client` types so that source written for Vite/tsdown type-checks the same way.

## Types added

- **Static assets** (images, media, fonts, `.webmanifest`, `.pdf`, `.txt`, …) — `string` default export
- **CSS** — side-effect imports (`*.css`, `*.scss`, …) and CSS Modules (`*.module.css` → class-name map)
- **`?raw`** — file contents as a `string`

## Intentionally omitted (Vite-only features with no plugboy loader)

To avoid types implying unsupported behavior, the following are not declared:

- `?url` / `?inline`, `?worker` / `?sharedworker`, `*.wasm?init`
- `vite/modulepreload-polyfill`, `vite:preloadError`
- `import.meta.env` (source should use `__PLUGBOY_DEV__` instead)

The rationale is documented in the header comment of `env.d.ts` and in the docs.

## Docs

- Added a "Module types" section to `docs/env-constants.md` / `docs/env-constants-ja.md` (covering Vite/tsdown compatibility and the omissions)
- Updated the feature bullet in README / README-ja to cover both the env constants and the module types

## Notes

- The tsconfig setup is shared with the existing one-line reference, so no duplicate setup instructions were added.
- `env.d.ts` type-checks cleanly on its own. Verifying CSS Modules at actual build time is out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)