### PR TITLE
fix(plugboy): make env.d.ts a script so ambient module declarations apply

### DIFF
--- a/.changeset/plugboy-env-ambient-module-fix.md
+++ b/.changeset/plugboy-env-ambient-module-fix.md
@@ -1,0 +1,5 @@
+---
+"@fastkit/plugboy": patch
+---
+
+Fix the Vite-compatible ambient module declarations in `@fastkit/plugboy/env` being inert on the consumer side. The trailing `export {}` made `env.d.ts` a module, and top-level wildcard `declare module '*.svg'` / `*?raw` / CSS declarations in a module file are not registered as global ambient modules — so importing an asset, a `?raw` file, or CSS still failed to type-check (`TS2307` / `TS2882`) even after referencing `@fastkit/plugboy/env`. The file is now a script (plain top-level `declare const` / `declare module`, no trailing `export {}`), so both the `__PLUGBOY_DEV__` / `__PLUGBOY_STUB__` constants and the module declarations apply globally. Fixes #172.

--- a/packages/plugboy/env.d.ts
+++ b/packages/plugboy/env.d.ts
@@ -1,23 +1,28 @@
-declare global {
-  /**
-   * Whether the code is running in a development context.
-   *
-   * @remarks
-   * - `stub`: always `true`.
-   * - published `build`: replaced with a runtime check of the consumer's
-   *   environment (`process.env.NODE_ENV === 'development'` or
-   *   `import.meta.env.DEV === true`), so the branch is evaluated at the
-   *   consumer's runtime rather than eliminated.
-   */
-  const __PLUGBOY_DEV__: boolean;
+// This file must remain a SCRIPT (no top-level `import`/`export`). A trailing
+// `export {}` would make it a module, and top-level wildcard `declare module
+// '*.svg'` declarations in a module file are NOT registered as global ambient
+// modules — they would silently fail to apply on the consumer side. Keeping the
+// file a script (plain top-level `declare const` / `declare module`) is what
+// makes both the constants and the module declarations below globally visible.
 
-  /**
-   * The bundle is in stub mode.
-   *
-   * @remarks In stub mode, source code is executed in the source directory. This flag is available because of the different way of loading files in relative paths.
-   */
-  const __PLUGBOY_STUB__: boolean;
-}
+/**
+ * Whether the code is running in a development context.
+ *
+ * @remarks
+ * - `stub`: always `true`.
+ * - published `build`: replaced with a runtime check of the consumer's
+ *   environment (`process.env.NODE_ENV === 'development'` or
+ *   `import.meta.env.DEV === true`), so the branch is evaluated at the
+ *   consumer's runtime rather than eliminated.
+ */
+declare const __PLUGBOY_DEV__: boolean;
+
+/**
+ * The bundle is in stub mode.
+ *
+ * @remarks In stub mode, source code is executed in the source directory. This flag is available because of the different way of loading files in relative paths.
+ */
+declare const __PLUGBOY_STUB__: boolean;
 
 // The declarations below mirror the subset of Vite's `vite/client` module
 // declarations that Plugboy is compatible with, so that source that already
@@ -231,5 +236,3 @@ declare module '*?raw' {
   const src: string;
   export default src;
 }
-
-export {};


### PR DESCRIPTION
Fixes #172

## Problem

The Vite-compatible ambient module declarations added in v1.2.0 (#170) — `*.svg` and other static assets, `*?raw`, `*.css` / CSS Modules — were **inert on the consumer side**. Referencing `@fastkit/plugboy/env` did not make them available, so importing an asset, a `?raw` file, or CSS still failed to type-check (`TS2307` / `TS2882`).

## Root cause

`env.d.ts` ended with `export {};`, which makes the whole file a **module**. In a module file, a top-level wildcard `declare module '*.svg' { … }` is **not** registered as a global ambient module declaration, so it never applies outside that file. The `__PLUGBOY_DEV__` / `__PLUGBOY_STUB__` constants kept working only because they were inside an explicit `declare global { … }` block.

## Fix

Make `env.d.ts` a **script** (no top-level `import`/`export`):

- Drop the trailing `export {};`.
- Replace the `declare global { … }` wrapper with plain top-level `declare const __PLUGBOY_DEV__` / `declare const __PLUGBOY_STUB__`.

Now both the constants and the wildcard module declarations are globally visible. A header comment documents why the file must stay a script.

## Verification

Reproduced the reported `TS2307` with the pre-fix structure, then confirmed the fixed `env.d.ts` resolves cleanly with `tsc --moduleResolution bundler --noEmit --strict`:

```ts
import logo from './a.svg';        // string
import raw from './b.txt?raw';     // string
import styles from './c.module.css'; // class-name map
import './d.css';                  // side-effect
const dev: boolean = __PLUGBOY_DEV__;
const stub: boolean = __PLUGBOY_STUB__;
```

All resolve with no errors (TypeScript 6.0.3, `moduleResolution: "Bundler"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)